### PR TITLE
Remove pflags added by any library

### DIFF
--- a/cmd/ketch/main.go
+++ b/cmd/ketch/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/exec"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -17,6 +18,10 @@ var (
 )
 
 func main() {
+
+	// Remove any flags that were added by libraries automatically.
+	pflag.CommandLine = pflag.NewFlagSet("ketch", pflag.ExitOnError)
+
 	cmd := newRootCmd(&configuration.Configuration{}, os.Stdout)
 	if err := cmd.Execute(); err != nil {
 		fmt.Printf("%v\n", err)


### PR DESCRIPTION
# Remove pflags added by any library

One of our dependencies adds a global [flag](https://github.com/vdemeester/k8s-pkg-credentialprovider/blob/v1.18.0/azure/azure_credentials.go#L40). 

This commit removes pflags added by any library.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


