### PR TITLE
Simplify chart.New

### DIFF
--- a/cmd/ketch/app_info.go
+++ b/cmd/ketch/app_info.go
@@ -17,7 +17,7 @@ import (
 var (
 	appInfoTemplate = `Application: {{ .App.Name }}
 Description: {{ .App.Spec.Description }}
-{{- range $address := .URLs }}
+{{- range $address := .Cnames }}
 Address: {{ $address }}
 {{- end }}
 Deploys: {{ .App.Spec.DeploymentsCount }}
@@ -32,8 +32,8 @@ Routing settings:
 )
 
 type appInfoContext struct {
-	App  ketchv1.App
-	URLs []string
+	App    ketchv1.App
+	Cnames []string
 }
 
 const appInfoHelp = `
@@ -43,7 +43,7 @@ Show information about a specific app.
 func newAppInfoCmd(cfg config, out io.Writer) *cobra.Command {
 	options := appInfoOptions{}
 	cmd := &cobra.Command{
-		Use:   "info",
+		Use:   "info APPNAME",
 		Short: "Show information about a specific app.",
 		Args:  cobra.ExactArgs(1),
 		Long:  appInfoHelp,
@@ -74,8 +74,8 @@ func appInfo(ctx context.Context, cfg config, options appInfoOptions, out io.Wri
 	buf := bytes.Buffer{}
 	t := template.Must(template.New("app-info").Parse(appInfoTemplate))
 	infoContext := appInfoContext{
-		App:  app,
-		URLs: app.URLs(pool),
+		App:    app,
+		Cnames: app.CNames(pool),
 	}
 	if err := t.Execute(&buf, infoContext); err != nil {
 		return err

--- a/cmd/ketch/app_list.go
+++ b/cmd/ketch/app_list.go
@@ -46,7 +46,7 @@ func appList(ctx context.Context, cfg config, out io.Writer) error {
 	fmt.Fprintln(w, "NAME\tPOOL\tSTATUS\tUNITS\tADDRESSES\tDESCRIPTION")
 	for _, item := range apps.Items {
 		pool := poolsByName[item.Spec.Pool]
-		urls := strings.Join(item.URLs(&pool), " ")
+		urls := strings.Join(item.CNames(&pool), " ")
 		line := []string{item.Name, item.Spec.Pool, string(item.Status.Phase), fmt.Sprintf("%d", item.Units()), urls, item.Spec.Description}
 		fmt.Fprintln(w, strings.Join(line, "\t"))
 	}

--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -450,7 +450,7 @@ spec:
                   type: array
                 generateDefaultCname:
                   description: GenerateDefaultCname if set the application will have
-                    a default url <app-name>.<ServiceEndpoint>.shipa.cloud.
+                    a default cname <app-name>.<ServiceEndpoint>.shipa.cloud.
                   type: boolean
               required:
               - generateDefaultCname

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -97,7 +97,7 @@ type AppDeploymentSpec struct {
 // IngressSpec configures entrypoints to access an application.
 type IngressSpec struct {
 
-	// GenerateDefaultCname if set the application will have a default url <app-name>.<ServiceEndpoint>.shipa.cloud.
+	// GenerateDefaultCname if set the application will have a default cname <app-name>.<ServiceEndpoint>.shipa.cloud.
 	GenerateDefaultCname bool `json:"generateDefaultCname"`
 
 	// Cnames is a list of additional cnames.
@@ -376,21 +376,21 @@ func (app *App) Start(selector Selector) error {
 	return nil
 }
 
-// URLs returns all CNAMEs to access the application including a default url.
-func (app *App) URLs(pool *Pool) []string {
-	defaultUrl := app.DefaultURL(pool)
-	if defaultUrl == nil {
+// CNames returns all CNAMEs to access the application including a default cname.
+func (app *App) CNames(pool *Pool) []string {
+	defaultCname := app.DefaultCname(pool)
+	if defaultCname == nil {
 		if len(app.Spec.Ingress.Cnames) == 0 {
 			return []string{}
 		}
 		return app.Spec.Ingress.Cnames
 	}
-	return append([]string{*defaultUrl}, app.Spec.Ingress.Cnames...)
+	return append([]string{*defaultCname}, app.Spec.Ingress.Cnames...)
 }
 
-// DefaultURL returns a default url to access the application.
-// A default url uses the following format: <app name>.<pool's ServiceEndpoint>.shipa.cloud.
-func (app *App) DefaultURL(pool *Pool) *string {
+// DefaultCname returns a default cname to access the application.
+// A default cname uses the following format: <app name>.<pool's ServiceEndpoint>.shipa.cloud.
+func (app *App) DefaultCname(pool *Pool) *string {
 	if pool == nil {
 		return nil
 	}

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -507,7 +507,7 @@ func TestApp_UnsetEnvs(t *testing.T) {
 	}
 }
 
-func TestApp_DefaultURL(t *testing.T) {
+func TestApp_DefaultCname(t *testing.T) {
 	tests := []struct {
 		name                 string
 		appName              string
@@ -516,7 +516,7 @@ func TestApp_DefaultURL(t *testing.T) {
 		want                 *string
 	}{
 		{
-			name:                 "url with a custom domain",
+			name:                 "cname with a custom domain",
 			appName:              "app-1",
 			generateDefaultCname: true,
 			pool: &Pool{
@@ -530,7 +530,7 @@ func TestApp_DefaultURL(t *testing.T) {
 			want: stringRef("app-1.10.20.30.40.theketch.io"),
 		},
 		{
-			name:                 "url with default domain",
+			name:                 "cname with default domain",
 			appName:              "app-2",
 			generateDefaultCname: true,
 			pool: &Pool{
@@ -543,13 +543,13 @@ func TestApp_DefaultURL(t *testing.T) {
 			want: stringRef("app-2.20.20.20.20.shipa.cloud"),
 		},
 		{
-			name:                 "no service endpoint - no default url",
+			name:                 "no service endpoint - no default cname",
 			appName:              "app-1",
 			generateDefaultCname: true,
 			pool:                 &Pool{},
 		},
 		{
-			name:                 "do not generate default cname - no default url",
+			name:                 "do not generate default cname - no default cname",
 			appName:              "app-1",
 			generateDefaultCname: false,
 			pool: &Pool{
@@ -573,15 +573,15 @@ func TestApp_DefaultURL(t *testing.T) {
 					},
 				},
 			}
-			got := app.DefaultURL(tt.pool)
+			got := app.DefaultCname(tt.pool)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("DefaultURL() mismatch (-want +got):\n%s", diff)
+				t.Errorf("DefaultCname() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestApp_URLs(t *testing.T) {
+func TestApp_CNames(t *testing.T) {
 	tests := []struct {
 		name                 string
 		generateDefaultCname bool
@@ -632,9 +632,9 @@ func TestApp_URLs(t *testing.T) {
 					},
 				},
 			}
-			got := app.URLs(pool)
+			got := app.CNames(pool)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("URLs() mismatch (-want +got):\n%s", diff)
+				t.Errorf("CNames() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/controllers/app_controller.go
+++ b/internal/controllers/app_controller.go
@@ -139,7 +139,11 @@ func (r *AppReconciler) reconcile(ctx context.Context, app *ketchv1.App) ketchv1
 			Message: fmt.Sprintf(`you have reached the limit of apps`),
 		}
 	}
-	appChrt, err := chart.New(app.Name, app.Spec, pool.Spec, chart.WithExposedPorts(app.ExposedPorts()), chart.WithTemplates(*tpls))
+	options := []chart.Option{
+		chart.WithExposedPorts(app.ExposedPorts()),
+		chart.WithTemplates(*tpls),
+	}
+	appChrt, err := chart.New(app, &pool, options...)
 	if err != nil {
 		return ketchv1.AppStatus{
 			Phase:   ketchv1.AppFailed,


### PR DESCRIPTION
 Simplify ctor of ApplicationChart
    
     This commit does the following:
         * removes code that generates a default cname in chart.New.
    
               Now there is a single function that constructs a default cname and the
            a single function that returns a full list of all cnames of an
            application including a default cname.
    
          * move code to construct a Procfile from a list of ProcessSpec to a separate function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

