### PR TITLE
Consistent use of positional arguments

### DIFF
--- a/cmd/ketch/app.go
+++ b/cmd/ketch/app.go
@@ -19,10 +19,10 @@ func newAppCmd(cfg config, out io.Writer) *cobra.Command {
 	cmd.AddCommand(newAppDeployCmd(cfg, out))
 	cmd.AddCommand(newAppUpdateCmd(cfg, out))
 	cmd.AddCommand(newAppListCmd(cfg, out))
-	cmd.AddCommand(newAppRemoveCmd(cfg, out))
+	cmd.AddCommand(newAppRemoveCmd(cfg, out, appRemove))
 	cmd.AddCommand(newAppInfoCmd(cfg, out))
-	cmd.AddCommand(newAppStartCmd(cfg, out))
-	cmd.AddCommand(newAppStopCmd(cfg, out))
+	cmd.AddCommand(newAppStartCmd(cfg, out, appStart))
+	cmd.AddCommand(newAppStopCmd(cfg, out, appStop))
 	cmd.AddCommand(newAppExportCmd(cfg, out))
 	return cmd
 }

--- a/cmd/ketch/app_remove_test.go
+++ b/cmd/ketch/app_remove_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/shipa-corp/ketch/internal/templates"
+)
+
+type mockConfig struct{}
+
+func (m mockConfig) Client() client.Client {
+	panic("implement me")
+}
+
+func (m mockConfig) Storage() templates.Client {
+	panic("implement me")
+}
+
+func (m mockConfig) KubernetesClient() kubernetes.Interface {
+	panic("implement me")
+}
+
+func TestAppRemoveCmd(t *testing.T) {
+	pflag.CommandLine = pflag.NewFlagSet("ketch", pflag.ExitOnError)
+
+	tt := []struct {
+		description string
+		args        []string
+		appRemover  appRemoveFn
+		wantErr     bool
+	}{
+		{
+			description: "happy path",
+			args:        []string{"ketch", "foo-bar"},
+			appRemover: func(_ context.Context, _ config, appName string, _ io.Writer) error {
+				require.Equal(t, "foo-bar", appName)
+				return nil
+			},
+		},
+		{
+			description: "bad app name",
+			args:        []string{"ketch", "foo@bar"},
+			wantErr:     true,
+		},
+		{
+			description: "missing positional arg",
+			args:        []string{"ketch"},
+			wantErr:     true,
+		},
+		{
+			description: "too many positional args",
+			args:        []string{"ketch", "foo-bar", "extra"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			os.Args = tc.args
+			cmd := newAppRemoveCmd(nil, nil, tc.appRemover)
+			err := cmd.Execute()
+			if tc.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
+
+		})
+	}
+}

--- a/cmd/ketch/app_start_test.go
+++ b/cmd/ketch/app_start_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppStart(t *testing.T) {
+	pflag.CommandLine = pflag.NewFlagSet("ketch", pflag.ExitOnError)
+
+	tt := []struct {
+		description string
+		args        []string
+		appStart    appStartFn
+		wantErr     bool
+	}{
+		{
+			description: "happy path",
+			args:        []string{"ketch", "myapp", "-p", "myprocess", "-v", "2"},
+			appStart: func(_ context.Context, _ config, opts appStartOptions, _ io.Writer) error {
+				require.Equal(t, "myapp", opts.appName)
+				require.Equal(t, "myprocess", opts.processName)
+				require.Equal(t, 2, opts.deploymentVersion)
+				return nil
+			},
+		},
+		{
+			description: "missing positional",
+			args:        []string{"ketch", "-p", "myprocess", "-v", "2"},
+			wantErr:     true,
+		},
+		{
+			description: "extra positional",
+			args:        []string{"ketch", "myapp", "extra", "-p", "myprocess", "-v", "2"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			os.Args = tc.args
+			cmd := newAppStartCmd(nil, nil, tc.appStart)
+			err := cmd.Execute()
+			if tc.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
+
+		})
+	}
+}

--- a/cmd/ketch/app_stop_test.go
+++ b/cmd/ketch/app_stop_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppStop(t *testing.T) {
+	pflag.CommandLine = pflag.NewFlagSet("ketch", pflag.ExitOnError)
+
+	tt := []struct {
+		description string
+		args        []string
+		appStop     appStopFn
+		wantErr     bool
+	}{
+		{
+			description: "happy path",
+			args:        []string{"ketch", "myapp", "-p", "myprocess", "-v", "3"},
+			appStop: func(_ context.Context, _ config, opts appStopOptions, _ io.Writer) error {
+				require.Equal(t, "myapp", opts.appName)
+				require.Equal(t, "myprocess", opts.processName)
+				require.Equal(t, 3, opts.deploymentVersion)
+				return nil
+			},
+		},
+		{
+			description: "missing positional arg",
+			args:        []string{"ketch", "-p", "myprocess", "-v", "3"},
+			wantErr:     true,
+		},
+		{
+			description: "too many positionals",
+			args:        []string{"ketch", "myapp", "extra", "-p", "myprocess", "-v", "3"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			os.Args = tc.args
+			cmd := newAppStopCmd(nil, nil, tc.appStop)
+			err := cmd.Execute()
+			if tc.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Some `ketch app` commands took the app name as a positional argument, and other commands required an `-a` flag.  This was confusing.  This change removes the need for the `-a` flag, requiring all app names are passed as a positional argument. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
