### PR TITLE
Added script to install kustomize from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ jobs:
       sudo: required
       script:
         - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-        - docker build -t shipasoftware/ketch:$TRAVIS_PULL_REQUEST_BRANCH .
-        - docker push shipasoftware/ketch:$TRAVIS_PULL_REQUEST_BRANCH
+        - docker build -t shipasoftware/ketch:$TRAVIS_COMMIT .
+        - docker push shipasoftware/ketch:$TRAVIS_COMMIT

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ install-kubebuilder:
 
 .PHONY: install-kustomize
 install-kustomize:
-	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-	mv kustomize ${KUSTOMIZE_INSTALL_DIR}/
+	@script/install-kustomize.sh
 
 # Uninstall CRDs from a cluster
 .PHONY: uninstall

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 KUBEBUILDER_VERSION="1.0.8"
 KUBEBUILDER_INSTALL_DIR ?= "/usr/local"
 
-KUSTOMIZE ?= $(shell which kustomize)
-KUSTOMIZE_INSTALL_DIR ?= "/usr/local/bin"
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -99,9 +96,9 @@ docker-push:
 	docker push ${IMG}
 
 .PHONY: create-controller-yaml
-create-controller-yaml:
-	cd config/manager && ${KUSTOMIZE} edit set image controller=${IMG} && cd ../../
-	${KUSTOMIZE} build config/default > ketch-controller.yaml
+create-controller-yaml: install-kustomize
+	cd config/manager && kustomize edit set image controller=${IMG} && cd ../../
+	kustomize build config/default > ketch-controller.yaml
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/script/install-kustomize.sh
+++ b/script/install-kustomize.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
 
-set -euxo pipefail
+set -euo pipefail
+
+kustomize_version="${KUSTOMIZE_VERSION:-v3.3.1}"
+
+if command -v kustomize > /dev/null 
+then
+    echo "kustomize already installed, installation skipped"
+    exit
+fi
+
+echo "Installing kustomize ${kustomize_version} from source"
 
 curr_dir=$(pwd)
 
@@ -10,7 +20,7 @@ cd "${tmp_dir}"
 
 git clone ssh://git@github.com/kubernetes-sigs/kustomize
 cd kustomize
-git checkout v3.3.1
+git checkout "${kustomize_version}"
 cd kustomize
 go install .
 

--- a/script/install-kustomize.sh
+++ b/script/install-kustomize.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+set -euxo pipefail
+
+curr_dir=$(pwd)
+
+tmp_dir=$(mktemp -d -t kustomize-XXXXXXXXXX)
+cd "${tmp_dir}"
+
+git clone ssh://git@github.com/kubernetes-sigs/kustomize
+cd kustomize
+git checkout v3.3.1
+cd kustomize
+go install .
+
+cd "${curr_dir}"
+
+rm -rf "${tmp_dir}" 


### PR DESCRIPTION
# Description

The kustomize script to install binaries was broken which in turn broke our Makefile.  The PR adds a script to install kustomize from source if kustomize is not already installed.  It has a number of advantages over the old way of doing things.

1. Tagged source history is almost always immutable, the likelihood that a breaking change will be introduced from the kustomize project is low. 
1. This script will not silently overwrite a user's existing kustomize install like the old install would. 
1. The criticism that this approach will increase build times is unwarranted.  While it is true that the install will increase build time, it's the increase would be no more than importing an additional package into the project which we do all the time without a second thought.  On a development machine, it's a one time 4 second hit. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
