### PR TITLE
[SHIPA-808] make dir with app name for saving chart with export cmd

### DIFF
--- a/cmd/ketch/app_export_test.go
+++ b/cmd/ketch/app_export_test.go
@@ -7,7 +7,9 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
+	"bou.ke/monkey"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +73,6 @@ func (m mockStorage) Update(name string, templates templates.Templates) error {
 var _ templates.Client = &mockStorage{}
 
 func Test_appExport(t *testing.T) {
-
 	directory1, err := ioutil.TempDir("", "ketch-app-export")
 	require.Nil(t, err)
 
@@ -163,7 +164,10 @@ func Test_appExport(t *testing.T) {
 			}
 			require.Nil(t, err)
 			require.Equal(t, tt.wantOut, out.String())
-			files, err := ioutil.ReadDir(tt.options.directory + "/" + tt.options.appName)
+			// safely patch time.Now for tests
+			patch := monkey.Patch(time.Now, func() time.Time { return time.Date(2020, 12, 11, 20, 34, 58, 651387237, time.UTC) })
+			defer patch.Unpatch()
+			files, err := ioutil.ReadDir(tt.options.directory + "/" + tt.options.appName + "_11_Dec_20_20_34_UTC")
 			require.Nil(t, err)
 
 			directoryContent := make(map[string]struct{})

--- a/cmd/ketch/app_export_test.go
+++ b/cmd/ketch/app_export_test.go
@@ -157,6 +157,7 @@ func Test_appExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// safely patch time.Now for tests
 			patch := monkey.Patch(time.Now, func() time.Time { return time.Date(2020, 12, 11, 20, 34, 58, 651387237, time.UTC) })
+			defer patch.Unpatch()
 			out := &bytes.Buffer{}
 			err := appExport(context.Background(), tt.cfg, tt.chartNew, tt.options, out)
 			if len(tt.wantErr) > 0 {
@@ -179,7 +180,6 @@ func Test_appExport(t *testing.T) {
 				"values.yaml": {},
 			}
 			require.Equal(t, expected, directoryContent)
-			patch.Unpatch()
 		})
 	}
 }

--- a/cmd/ketch/app_export_test.go
+++ b/cmd/ketch/app_export_test.go
@@ -163,7 +163,7 @@ func Test_appExport(t *testing.T) {
 			}
 			require.Nil(t, err)
 			require.Equal(t, tt.wantOut, out.String())
-			files, err := ioutil.ReadDir(tt.options.directory)
+			files, err := ioutil.ReadDir(tt.options.directory + "/" + tt.options.appName)
 			require.Nil(t, err)
 
 			directoryContent := make(map[string]struct{})

--- a/cmd/ketch/app_export_test.go
+++ b/cmd/ketch/app_export_test.go
@@ -155,6 +155,8 @@ func Test_appExport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// safely patch time.Now for tests
+			patch := monkey.Patch(time.Now, func() time.Time { return time.Date(2020, 12, 11, 20, 34, 58, 651387237, time.UTC) })
 			out := &bytes.Buffer{}
 			err := appExport(context.Background(), tt.cfg, tt.chartNew, tt.options, out)
 			if len(tt.wantErr) > 0 {
@@ -164,9 +166,6 @@ func Test_appExport(t *testing.T) {
 			}
 			require.Nil(t, err)
 			require.Equal(t, tt.wantOut, out.String())
-			// safely patch time.Now for tests
-			patch := monkey.Patch(time.Now, func() time.Time { return time.Date(2020, 12, 11, 20, 34, 58, 651387237, time.UTC) })
-			defer patch.Unpatch()
 			files, err := ioutil.ReadDir(tt.options.directory + "/" + tt.options.appName + "_11_Dec_20_20_34_UTC")
 			require.Nil(t, err)
 
@@ -180,6 +179,7 @@ func Test_appExport(t *testing.T) {
 				"values.yaml": {},
 			}
 			require.Equal(t, expected, directoryContent)
+			patch.Unpatch()
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shipa-corp/ketch
 go 1.15
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.1
 	github.com/google/go-containerregistry v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -235,7 +235,7 @@ func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig Cha
 	replacer := strings.NewReplacer(" ", "_", ":", "_")
 	targetDir := directory + "/" + chartConfig.AppName + "_" + replacer.Replace(timestamp)
 
-	err = os.MkdirAll(filepath.Join(targetDir, "templates"), os.ModePerm)
+	err := os.MkdirAll(filepath.Join(targetDir, "templates"), os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -241,7 +241,7 @@ func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig Cha
 		return err
 	}
 	for filename, content := range chrt.templates {
-		path := filepath.Join(targetDir, "templates", filename)
+		path := filepath.Join(targetDir, filename)
 		err = ioutil.WriteFile(path, []byte(content), 0644)
 		if err != nil {
 			return err

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -229,16 +229,17 @@ func (config ChartConfig) render() ([]byte, error) {
 // ExportToDirectory saves the chart to the provided directory.
 // Be careful because the previous content of the directory is removed.
 func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig ChartConfig) error {
-	err := os.RemoveAll(directory)
+	targetDir := directory + "/" + chartConfig.AppName
+	err := os.RemoveAll(targetDir)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(filepath.Join(directory, "templates"), os.ModePerm)
+	err = os.MkdirAll(filepath.Join(targetDir, "templates"), os.ModePerm)
 	if err != nil {
 		return err
 	}
 	for filename, content := range chrt.templates {
-		path := filepath.Join(directory, "templates", filename)
+		path := filepath.Join(targetDir, "templates", filename)
 		err = ioutil.WriteFile(path, []byte(content), 0644)
 		if err != nil {
 			return err
@@ -248,7 +249,7 @@ func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig Cha
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(directory, "values.yaml"), valuesBytes, 0644)
+	err = ioutil.WriteFile(filepath.Join(targetDir, "values.yaml"), valuesBytes, 0644)
 	if err != nil {
 		return err
 	}
@@ -256,7 +257,7 @@ func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig Cha
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(directory, "Chart.yaml"), chartYamlContent, 0644)
+	err = ioutil.WriteFile(filepath.Join(targetDir, "Chart.yaml"), chartYamlContent, 0644)
 	if err != nil {
 		return err
 	}

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -233,7 +233,7 @@ func (config ChartConfig) render() ([]byte, error) {
 func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig ChartConfig) error {
 	timestamp := time.Now().Format(time.RFC822)
 	replacer := strings.NewReplacer(" ", "_", ":", "_")
-	chartDir := config.AppName + "_" + replacer.Replace(timestamp)
+	chartDir := chartConfig.AppName + "_" + replacer.Replace(timestamp)
 	targetDir := filepath.Join(directory, chartDir, "templates")
 
 	err := os.MkdirAll(targetDir, os.ModePerm)

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -233,9 +233,10 @@ func (config ChartConfig) render() ([]byte, error) {
 func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig ChartConfig) error {
 	timestamp := time.Now().Format(time.RFC822)
 	replacer := strings.NewReplacer(" ", "_", ":", "_")
-	targetDir := directory + "/" + chartConfig.AppName + "_" + replacer.Replace(timestamp)
+	chartDir := config.AppName + "_" + replacer.Replace(timestamp)
+	targetDir := filepath.Join(directory, chartDir, "templates")
 
-	err := os.MkdirAll(filepath.Join(targetDir, "templates"), os.ModePerm)
+	err := os.MkdirAll(targetDir, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -9,7 +9,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
+	"time"
 
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -226,14 +228,13 @@ func (config ChartConfig) render() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// ExportToDirectory saves the chart to the provided directory.
-// Be careful because the previous content of the directory is removed.
+// ExportToDirectory saves the chart to the provided directory inside a folder with app_Name_TIMESTAMP
+//  for example, for any app with name `hello`, it will save chart inside a folder with name `hello_11_Dec_20_12_30_IST`
 func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig ChartConfig) error {
-	targetDir := directory + "/" + chartConfig.AppName
-	err := os.RemoveAll(targetDir)
-	if err != nil {
-		return err
-	}
+	timestamp := time.Now().Format(time.RFC822)
+	replacer := strings.NewReplacer(" ", "_", ":", "_")
+	targetDir := directory + "/" + chartConfig.AppName + "_" + replacer.Replace(timestamp)
+
 	err = os.MkdirAll(filepath.Join(targetDir, "templates"), os.ModePerm)
 	if err != nil {
 		return err

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -234,14 +234,14 @@ func (chrt ApplicationChart) ExportToDirectory(directory string, chartConfig Cha
 	timestamp := time.Now().Format(time.RFC822)
 	replacer := strings.NewReplacer(" ", "_", ":", "_")
 	chartDir := chartConfig.AppName + "_" + replacer.Replace(timestamp)
-	targetDir := filepath.Join(directory, chartDir, "templates")
+	targetDir := filepath.Join(directory, chartDir)
 
-	err := os.MkdirAll(targetDir, os.ModePerm)
+	err := os.MkdirAll(filepath.Join(targetDir, "templates"), os.ModePerm)
 	if err != nil {
 		return err
 	}
 	for filename, content := range chrt.templates {
-		path := filepath.Join(targetDir, filename)
+		path := filepath.Join(targetDir, "templates", filename)
 		err = ioutil.WriteFile(path, []byte(content), 0644)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

https://shipaio.atlassian.net/browse/SHIPA-808

Currently, ketch wipes all the data of the directory before exporting a chart that we pass with ketch app export cmd. This wiping of all data from a parent dir could cause a lot of serious problems. For example, if the user sets the directory path to `/Users/username` it will wipe all data inside it.

My proposal to fix it:

- on ketch export, make a folder with `appName_TIMESTAMP` inside the user-provided path and save the exported chart data inside it to keep parent dir safe.
- With this approach, a user could save multiple app charts inside a parent dir.
- timestamp can help them to identify the latest one
- user will not lose the older charts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
