### PR TITLE
[SHIPA-723] support Canary deployment with ketch

### DIFF
--- a/cmd/ketch/app_deploy.go
+++ b/cmd/ketch/app_deploy.go
@@ -40,6 +40,10 @@ func newAppDeployCmd(cfg config, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&options.procfileFileName, "procfile", "", "the path to Procfile. If not set, ketch will use entrypoint and cmd from the image")
 	cmd.Flags().StringVar(&options.ketchYamlFileName, "ketch-yaml", "", "the path to ketch.yaml")
 	cmd.Flags().BoolVar(&options.strictKetchYamlDecoding, "strict", false, "strict decoding of ketch.yaml")
+	cmd.Flags().IntVar(&options.steps, "steps", 1, "Number of steps to roll out the new deployment")
+	cmd.Flags().IntVar(&options.stepWeight, "step-weight", 1, "Canary Traffic weight percentage between 0 and 100")
+	cmd.Flags().StringVar(&options.stepTimeInterval, "step-interval", "0", "Time interval between each step. Supported min: m, hour:h, second:s. ex. 1m, 60s, 1h")
+
 	cmd.MarkFlagRequired("image")
 
 	return cmd

--- a/cmd/ketch/app_deploy.go
+++ b/cmd/ketch/app_deploy.go
@@ -51,6 +51,9 @@ type appDeployOptions struct {
 	ketchYamlFileName       string
 	procfileFileName        string
 	strictKetchYamlDecoding bool
+	steps                   int
+	stepWeight              int
+	stepTimeInterval        string
 }
 
 type getImageConfigFileFn func(ctx context.Context, kubeClient kubernetes.Interface, args getImageConfigArgs, fn getRemoteImageFn) (*registryv1.ConfigFile, error)


### PR DESCRIPTION
# Description

As a user I can deploy my application using canary technique. It should follow similar convention as Shipa.

Acceptance criteria

Ketch deployment CLI to support --steps, --step-interval, --step-weight. 
e.g. `ketch app deploy --step-interval 30s steps 5 --step-weight 20`

- Canary deployment of application using Traefik ingress controller

- Canary deployment of application using Istio ingress controller

- Documentation updated to describe canary deployment

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
