### PR TITLE
Check if pool exists before creating app

### DIFF
--- a/cmd/ketch/app_create.go
+++ b/cmd/ketch/app_create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/validation"
@@ -71,6 +72,10 @@ func appCreate(ctx context.Context, cfg config, options appCreateOptions, out io
 				SecretName: options.dockerRegistrySecret,
 			},
 		},
+	}
+	var pool ketchv1.Pool
+	if err := cfg.Client().Get(ctx, types.NamespacedName{Name: app.Spec.Pool}, &pool); err != nil {
+		return fmt.Errorf("failed to get pool instance: %w", err)
 	}
 	if err = cfg.Client().Create(ctx, &app); err != nil {
 		return fmt.Errorf("failed to create an app: %w", err)

--- a/cmd/ketch/app_create_test.go
+++ b/cmd/ketch/app_create_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
+	"github.com/shipa-corp/ketch/internal/mocks"
+)
+
+func Test_appCreateFailsWithInvalidPool(t *testing.T) {
+	app := &ketchv1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testapp",
+		},
+		Spec: ketchv1.AppSpec{
+			Pool: "invalid-pool",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		cfg     config
+		options appCreateOptions
+		wantErr string
+	}{
+		{
+			name: "error - no pool",
+			cfg: &mocks.Configuration{
+				CtrlClientObjects: []runtime.Object{app},
+			},
+			options: appCreateOptions{
+				name: app.Name,
+				pool: app.Spec.Pool,
+			},
+			wantErr: `failed to get pool instance: pools.theketch.io "invalid-pool" not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		out := &bytes.Buffer{}
+		err := appCreate(context.Background(), tt.cfg, tt.options, out)
+		wantErr := len(tt.wantErr) > 0
+		if (err != nil) != wantErr {
+			t.Errorf("appCreate() error = %v, wantErr %v", err, tt.wantErr)
+			return
+		}
+		if wantErr {
+			assert.Equal(t, tt.wantErr, err.Error())
+			return
+		}
+	}
+}


### PR DESCRIPTION
# Description

This PR introduces a check for pool validity with `app create` .

Prior to this PR Ketch did not check existence of pool passed in with `app create`, resulting in the ability to create applications with invalid pools.  Although an invalid or nonexistent pool would be detected with `app deploy`, catching this issue as early as possible (with `app create`) improves UX. 

Fixes #34

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)

  - Added test to ensure app is not created if invalid pool is passed to `app create`

- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
