### PR TITLE
use commit for travis image name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ jobs:
       sudo: required
       script:
         - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-        - docker build -t shipasoftware/ketch:$TRAVIS_PULL_REQUEST_BRANCH .
-        - docker push shipasoftware/ketch:$TRAVIS_PULL_REQUEST_BRANCH
+        - docker build -t shipasoftware/ketch:$TRAVIS_COMMIT .
+        - docker push shipasoftware/ketch:$TRAVIS_COMMIT


### PR DESCRIPTION
# Description

Currently Ketch build job uses PR branch name as docker image tag:

https://github.com/shipa-corp/ketch/blob/161c4ba2ec41c45bf72667aaa2c980ded1495225/.travis.yml#L28

This causes docker build to fail when `$TRAVIS_PULL_REQUEST_BRANCH` contains a `/`. This PR uses the current commit (env var `$TRAVIS_COMMIT`) instead of PR branch for image tag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

