### PR TITLE
Sort ports exposed by an image to get repeatable deployment

### DIFF
--- a/cmd/ketch/app_deploy.go
+++ b/cmd/ketch/app_deploy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"sort"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -102,8 +103,13 @@ func appDeploy(ctx context.Context, cfg config, getImageConfigFile getImageConfi
 			Cmd:  cmd,
 		})
 	}
-	exposedPorts := make([]ketchv1.ExposedPort, 0, len(configFile.Config.ExposedPorts))
+	ports:= make([]string, 0, len(configFile.Config.ExposedPorts))
 	for port := range configFile.Config.ExposedPorts {
+		ports = append(ports, port)
+	}
+	sort.Strings(ports)
+	exposedPorts := make([]ketchv1.ExposedPort, 0, len(configFile.Config.ExposedPorts))
+	for _, port := range ports {
 		exposedPort, err := ketchv1.NewExposedPort(port)
 		if err != nil {
 			// Shouldn't happen


### PR DESCRIPTION
# Description

This commit sorts ports exposed by a docker image with an EXPOSE statement to get repeatable deployment.
Because If there is no ketch.yaml, we use the first port from the list.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)

