### PR TITLE
remove namespace with pool remove command

### DIFF
--- a/cmd/ketch/pool_remove.go
+++ b/cmd/ketch/pool_remove.go
@@ -115,7 +115,7 @@ func removeNamespace(ctx context.Context, cfg config, pool *ketchv1.Pool) error 
 	var ns corev1.Namespace
 
 	if err := cfg.Client().Get(ctx, types.NamespacedName{Name: pool.Spec.NamespaceName}, &ns); err != nil {
-		return fmt.Errorf("failed to get namespace: %s", err)
+		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 
 	if err := cfg.Client().Delete(ctx, &ns); err != nil {

--- a/cmd/ketch/pool_remove.go
+++ b/cmd/ketch/pool_remove.go
@@ -50,7 +50,7 @@ func poolRemove(ctx context.Context, cfg config, options poolRemoveOptions, out 
 	}
 
 	if userWantsToRemoveNamespace(pool.Spec.NamespaceName, out) {
-		if err := namespaceHasAdditionalResources(ctx, cfg, &pool); err != nil {
+		if err := checkNamespaceAdditionalPools(ctx, cfg, &pool); err != nil {
 			printNsRemovalErr(out, err)
 		} else {
 			if err := removeNamespace(ctx, cfg, &pool); err != nil {
@@ -93,7 +93,7 @@ func handleNamespaceRemovalResponse(response, ns string, out io.Writer) bool {
 	return true
 }
 
-func namespaceHasAdditionalResources(ctx context.Context, cfg config, targetPool *ketchv1.Pool) error {
+func checkNamespaceAdditionalPools(ctx context.Context, cfg config, targetPool *ketchv1.Pool) error {
 	var pools ketchv1.PoolList
 
 	if err := cfg.Client().List(ctx, &pools); err != nil {

--- a/cmd/ketch/pool_remove.go
+++ b/cmd/ketch/pool_remove.go
@@ -19,10 +19,6 @@ Remove an existing pool.
 	skipNsRemovalMsg = "Skipping namespace removal..."
 )
 
-var (
-	printNsRemovalErr = func(out io.Writer, err error) { fmt.Fprintf(out, "%s\n%s", err, skipNsRemovalMsg) }
-)
-
 func newPoolRemoveCmd(cfg config, out io.Writer) *cobra.Command {
 	options := poolRemoveOptions{}
 	cmd := &cobra.Command{
@@ -109,6 +105,10 @@ func checkNamespaceAdditionalPools(ctx context.Context, cfg config, targetPool *
 	}
 
 	return nil
+}
+
+func printNsRemovalErr(out io.Writer, err error) {
+	fmt.Fprintf(out, "%s\n%s", err, skipNsRemovalMsg)
 }
 
 func removeNamespace(ctx context.Context, cfg config, pool *ketchv1.Pool) error {

--- a/cmd/ketch/pool_remove_test.go
+++ b/cmd/ketch/pool_remove_test.go
@@ -3,20 +3,17 @@ package main
 import (
 	"bytes"
 	"context"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"testing"
 
 	"gotest.tools/assert"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/mocks"
 )
 
-func Test_poolRemove(t *testing.T) {
+func TestPoolRemove(t *testing.T) {
 	testPool := &ketchv1.Pool{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -50,17 +47,18 @@ func Test_poolRemove(t *testing.T) {
 
 			if len(tt.wantErr) > 0 {
 				assert.Error(t, err, tt.wantErr)
+				return
 			}
 
-			// TODO: find a better way to test namespace removal in `poolRemove`.
-			// This doesn't actually check the `err` from `poolRemove`, which fails
-			// here because the `fake` client does not create a namespace when test
-			// pool is created.
-			if err := tt.cfg.Client().Get(context.Background(), types.NamespacedName{Name: tt.pool.Spec.NamespaceName}, &corev1.Namespace{}); err != nil && !errors.IsNotFound(err) {
-				t.Errorf("failed to get namespace: %s", err.Error())
-			} else {
-				assert.Check(t, errors.IsNotFound(err))
+			assert.NilError(t, err)
+
+			var pools ketchv1.PoolList
+			if err := tt.cfg.Client().List(context.Background(), &pools); err != nil {
+				t.Errorf("failed to list test pool: %s", err.Error())
+				return
 			}
+
+			assert.Equal(t, 0, len(pools.Items))
 		})
 	}
 }

--- a/cmd/ketch/pool_remove_test.go
+++ b/cmd/ketch/pool_remove_test.go
@@ -53,8 +53,9 @@ func Test_poolRemove(t *testing.T) {
 			}
 
 			// TODO: find a better way to test namespace removal in `poolRemove`.
-			// This doesn't actually check the `err` from `poolRemove`, which fails here because the `fake` client does not
-			// create a namespace when test pool is created.
+			// This doesn't actually check the `err` from `poolRemove`, which fails
+			// here because the `fake` client does not create a namespace when test
+			// pool is created.
 			if err := tt.cfg.Client().Get(context.Background(), types.NamespacedName{Name: tt.pool.Spec.NamespaceName}, &corev1.Namespace{}); err != nil && !errors.IsNotFound(err) {
 				t.Errorf("failed to get namespace: %s", err.Error())
 			} else {

--- a/cmd/ketch/pool_remove_test.go
+++ b/cmd/ketch/pool_remove_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"testing"
+
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
+	"github.com/shipa-corp/ketch/internal/mocks"
+)
+
+func Test_poolRemove(t *testing.T) {
+	testPool := &ketchv1.Pool{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pool",
+		},
+		Spec: ketchv1.PoolSpec{
+			NamespaceName: "test-namespace",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		cfg     config
+		options poolRemoveOptions
+		pool    *ketchv1.Pool
+		wantErr string
+	}{
+		{
+			name: "remove pool and associated namespace",
+			cfg: &mocks.Configuration{
+				CtrlClientObjects: []runtime.Object{testPool},
+			},
+			options: poolRemoveOptions{Name: testPool.Name},
+			pool:    testPool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := poolRemove(context.Background(), tt.cfg, tt.options, &bytes.Buffer{})
+
+			if len(tt.wantErr) > 0 {
+				assert.Error(t, err, tt.wantErr)
+			}
+
+			// TODO: find a better way to test namespace removal in `poolRemove`.
+			// This doesn't actually check the `err` from `poolRemove`, which fails here because the `fake` client does not
+			// create a namespace when test pool is created.
+			if err := tt.cfg.Client().Get(context.Background(), types.NamespacedName{Name: tt.pool.Spec.NamespaceName}, &corev1.Namespace{}); err != nil && !errors.IsNotFound(err) {
+				t.Errorf("failed to get namespace: %s", err.Error())
+			} else {
+				assert.Check(t, errors.IsNotFound(err))
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/thediveo/enumflag v0.10.1
+	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.3.1
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8

--- a/go.sum
+++ b/go.sum
@@ -1115,6 +1115,7 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 helm.sh/helm/v3 v3.3.1 h1:uc+ZUthJnWNSwqyIv1KCdQm0ewi0eAf6oRaWG2X1oo0=
 helm.sh/helm/v3 v3.3.1/go.mod h1:CyCGQa53/k1JFxXvXveGwtfJ4cuB9zkaBSGa5rnAiHU=


### PR DESCRIPTION
# Description

Kubebuilder does not remove namespaces with the deletion of Kubernetes objects, even if the namespace is empty.  This PR introduces three additional client calls to the `poolRemove` function:

1. Get the pool-to-be-removed so we have access to its namespace (only have pool name with cli args)
2. Get the namespace associated with the pool-to-be-removed
3. Remove the associated namespace

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

While I did write a test, I did not include it here.  The [fake client](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client/fake#ClientBuilder) included with Kubebuilder does not alter cluster namespace when creating a pool, so `poolRemove` fails with `failed to get namespace`.  I had a test that ignores this error, but it defeats the purpose of testing IMO so I left it out.

I did come across [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest#Environment.Start) which may enable us to test for namespace removal.  How do we feel about bringing this into our test suite? It is quite a bit more involved, setting up a full test environment + API Server.

With that said, I did test these changes locally and getting the namespace name from the pool lookup to remove the namespace works as expected, terminating the namespace associated with the pool-to-be-removed.

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

