### PR TITLE
[SHIPA-1022] Registry Auth fails on Mac

### DIFF
--- a/internal/docker/auth.go
+++ b/internal/docker/auth.go
@@ -2,20 +2,20 @@ package docker
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strings"
 
 	"github.com/docker/cli/cli/config"
-	cliTypes "github.com/docker/cli/cli/config/types"
-	"github.com/docker/docker/api/types"
-	"k8s.io/apimachinery/pkg/util/json"
-
 	"github.com/shipa-corp/ketch/internal/errors"
 )
 
-const officialHost = "docker"
+const (
+	officialHost = "docker"
+	dockerIndex  = "index.docker.io"
+)
 
-func getEncodedRegistryAuth(configPath string, regHost string, insecure bool) (string, error) {
-	cfg, err := config.Load(configPath)
+func getEncodedRegistryAuth(regHost string) (string, error) {
+	cfg, err := config.Load(config.Dir())
 	if err != nil {
 		return "", errors.Wrap(err, "could not load docker config")
 	}
@@ -32,29 +32,12 @@ func getEncodedRegistryAuth(configPath string, regHost string, insecure bool) (s
 }
 
 func norm(regHost string) string {
-	if regHost == "docker.io" {
-		return "index.docker.io"
+	if official(regHost) {
+		return dockerIndex
 	}
 	return regHost
 }
 
 func official(regHost string) bool {
 	return strings.Contains(regHost, officialHost)
-}
-
-func convert(auths map[string]cliTypes.AuthConfig) map[string]types.AuthConfig {
-	result := make(map[string]types.AuthConfig)
-	for k, v := range auths {
-		result[k] = types.AuthConfig{
-			Username:      v.Username,
-			Password:      v.Password,
-			Auth:          v.Auth,
-			Email:         v.Email,
-			ServerAddress: v.ServerAddress,
-			IdentityToken: v.IdentityToken,
-			RegistryToken: v.RegistryToken,
-		}
-
-	}
-	return result
 }

--- a/internal/docker/auth.go
+++ b/internal/docker/auth.go
@@ -19,6 +19,7 @@ func getEncodedRegistryAuth(regHost string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not load docker config")
 	}
+
 	auth, err := cfg.GetAuthConfig(norm(regHost))
 	if err != nil {
 		return "", errors.Wrap(err, "could not load auth from docker config")
@@ -28,16 +29,17 @@ func getEncodedRegistryAuth(regHost string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not json encode docker auth config")
 	}
+
 	return base64.URLEncoding.EncodeToString(jsonAuth), nil
 }
 
 func norm(regHost string) string {
-	if official(regHost) {
+	if isHostOfficial(regHost) {
 		return dockerIndex
 	}
 	return regHost
 }
 
-func official(regHost string) bool {
+func isHostOfficial(regHost string) bool {
 	return strings.Contains(regHost, officialHost)
 }

--- a/internal/docker/auth_integration_test.go
+++ b/internal/docker/auth_integration_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// this test runs against your local docker credential store.  It will be skipped unless
+// the acceptance build tag is included in go flags and environment variables are set
+// containing your user and password to test against.
 func Test_getEncodedRegistryAuth(t *testing.T) {
 	expectedUser, ok := os.LookupEnv("KETCH_TEST_DOCKER_USER")
 	if !ok {

--- a/internal/docker/auth_integration_test.go
+++ b/internal/docker/auth_integration_test.go
@@ -1,0 +1,33 @@
+// +build acceptance
+
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getEncodedRegistryAuth(t *testing.T) {
+	expectedUser, ok := os.LookupEnv("KETCH_TEST_DOCKER_USER")
+	if !ok {
+		t.Skip("env KETCH_TEST_DOCKER_USER missing")
+	}
+	expectedPwd, ok := os.LookupEnv("KETCH_TEST_DOCKER_PASSWORD")
+	if !ok {
+		t.Skip("env KETCH_TEST_DOCKER_PASSWORD missing")
+	}
+	res, err := getEncodedRegistryAuth("docker.io")
+	require.Nil(t, err)
+	b, err := base64.URLEncoding.DecodeString(res)
+	require.Nil(t, err)
+	var auth types.AuthConfig
+	err = json.Unmarshal(b, &auth)
+	require.Nil(t, err)
+	require.Equal(t, expectedUser, auth.Username)
+	require.Equal(t, expectedPwd, auth.Password)
+}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -6,12 +6,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"io"
+
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
-	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/shipa-corp/ketch/internal/errors"
 )


### PR DESCRIPTION
# Description

See [SHIPA-1022](https://shipaio.atlassian.net/browse/SHIPA-1022?atlOrigin=eyJpIjoiODhiM2UwY2ZkZDU2NGIyZmJjZTVlMjI4NDE3MDlhZjgiLCJwIjoiaiJ9). Ketch uses the same mechanism to obtain registry authentication credentials as the Docker CLI.  It relies on the Docker CLI being present in order to deploy applications from source. Docker needs to shell out to an operating system specific helper function that retrieves auth credentials from secret storage for the OS, for example, the keychain on the Mac. We were not handling that correctly.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
