### PR TITLE
[SHIPA-1021] Fix Ketch Hanging on Start Up

### DIFF
--- a/cmd/ketch/platform.go
+++ b/cmd/ketch/platform.go
@@ -29,31 +29,35 @@ func newPlatformCmd(cfg config, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-type justInTimeInvoker struct {
-	cfg config
+type justInTimeClient struct {
+	cfg clientCtor
+}
+
+type clientCtor interface {
+	Client() client.Client
 }
 
 // defers the creation of the client until we need it (Just In Time). The reason we do this is so that the application doesn't
 // attempt to connect to a k8s cluster unless we need to in order to avoid delays in say, showing help.
-func jit(cfg config) *justInTimeInvoker {
-	return &justInTimeInvoker{
+func jit(cfg clientCtor) *justInTimeClient {
+	return &justInTimeClient{
 		cfg: cfg,
 	}
 }
 
-func (rg *justInTimeInvoker) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+func (rg *justInTimeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 	return rg.cfg.Client().Create(ctx, obj, opts...)
 }
 
-func (rg *justInTimeInvoker) Get(ctx context.Context, name types.NamespacedName, object runtime.Object) error {
+func (rg *justInTimeClient) Get(ctx context.Context, name types.NamespacedName, object runtime.Object) error {
 	return rg.cfg.Client().Get(ctx, name, object)
 }
 
-func (rg *justInTimeInvoker) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+func (rg *justInTimeClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 	return rg.cfg.Client().Delete(ctx, obj, opts...)
 }
 
-func (rg *justInTimeInvoker) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+func (rg *justInTimeClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
 	return rg.cfg.Client().List(ctx, list, opts...)
 }
 

--- a/cmd/ketch/platform_test.go
+++ b/cmd/ketch/platform_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockClientCtor struct {
+	called bool
+}
+
+func (mc *mockClientCtor) Client() client.Client {
+	mc.called = true
+	return nil
+}
+
+func TestJustInTimeClient(t *testing.T) {
+	var cli mockClientCtor
+	_ = newPlatformAddCmd(jit(&cli), ioutil.Discard)
+	if cli.called {
+		t.Fatal("client should not get called")
+	}
+}


### PR DESCRIPTION
# Description

Ketch was hanging on start up because operations associated with platform were attempting to connect to a k8s cluster when the application started.  I fixed this by deferring the k8s connection until the cluster was actually needed, which would be after initialization.  

Fixes # [SHIPA-1021](https://shipaio.atlassian.net/browse/SHIPA-1021?atlOrigin=eyJpIjoiZTY2ZmJkZGYzYTBhNGNkODkwM2ZlNjk4YzU2M2ZlMTQiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
