### PR TITLE
Hardening ketch controller deployment

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -19,6 +19,13 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
       containers:
       - command:
         - /manager
@@ -36,4 +40,11 @@ spec:
           requests:
             cpu: 300m
             memory: 300Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
   We use gcr.io/distroless/static:nonroot image as a base image for ketch
controller and we have to explicitly define uid and gid to be able to use
RunAsNonRootUser: true.

  https://github.com/GoogleContainerTools/distroless/blob/master/base/testdata/base.yaml#L40

