### PR TITLE
 Proof of Concept - User Docker Creds to Generate Deploy Secret

### DIFF
--- a/cmd/ketch/app_deploy_test.go
+++ b/cmd/ketch/app_deploy_test.go
@@ -108,7 +108,7 @@ func Test_createProcfileFromImageEntrypointAndCmd(t *testing.T) {
 	tests := []struct {
 		name string
 
-		args           getImageConfigArgs
+		args           imageConfigArgs
 		mock           *mockRemoteImage
 		initialObjects []runtime.Object
 
@@ -118,7 +118,7 @@ func Test_createProcfileFromImageEntrypointAndCmd(t *testing.T) {
 	}{
 		{
 			name: "remote.Image error",
-			args: getImageConfigArgs{
+			args: imageConfigArgs{
 				imageName: "ketch:latest",
 			},
 			mock: &mockRemoteImage{
@@ -129,7 +129,7 @@ func Test_createProcfileFromImageEntrypointAndCmd(t *testing.T) {
 		},
 		{
 			name: "procfile with a private registry",
-			args: getImageConfigArgs{
+			args: imageConfigArgs{
 				imageName:       "ketch:latest",
 				secretName:      "top-secret",
 				secretNamespace: "secret-namespace",
@@ -164,7 +164,7 @@ func Test_createProcfileFromImageEntrypointAndCmd(t *testing.T) {
 		},
 		{
 			name: "secret not found",
-			args: getImageConfigArgs{
+			args: imageConfigArgs{
 				imageName:       "ketch:latest",
 				secretName:      "top-secret",
 				secretNamespace: "secret-namespace",
@@ -209,7 +209,7 @@ type mockGetImageConfig struct {
 	returnErr        error
 }
 
-func (m *mockGetImageConfig) get(ctx context.Context, kubeClient kubernetes.Interface, args getImageConfigArgs, fn getRemoteImageFn) (*registryv1.ConfigFile, error) {
+func (m *mockGetImageConfig) get(ctx context.Context, kubeClient kubernetes.Interface, args imageConfigArgs, fn getRemoteImageFn) (*registryv1.ConfigFile, error) {
 	return m.returnConfigFile, m.returnErr
 }
 

--- a/cmd/ketch/root.go
+++ b/cmd/ketch/root.go
@@ -28,6 +28,10 @@ type resourceCreator interface {
 	Create(context.Context, runtime.Object, ...client.CreateOption) error
 }
 
+type resourceUpdater interface {
+	Update(context.Context, runtime.Object, ...client.UpdateOption) error
+}
+
 type resourceLister interface {
 	List(context.Context, runtime.Object, ...client.ListOption) error
 }
@@ -43,6 +47,11 @@ type resourceDeleter interface {
 type resourceGetDeleter interface {
 	resourceGetter
 	resourceDeleter
+}
+
+type resourceUpdateCreator interface {
+	resourceCreator
+	resourceUpdater
 }
 
 // RootCmd represents the base command when called without any subcommands

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: murphybytes/ketch
   newTag: latest

--- a/internal/docker/auth.go
+++ b/internal/docker/auth.go
@@ -3,9 +3,11 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/docker/distribution/reference"
 	"strings"
 
 	"github.com/docker/cli/cli/config"
+	"github.com/docker/docker/api/types"
 	"github.com/shipa-corp/ketch/internal/errors"
 )
 
@@ -14,15 +16,40 @@ const (
 	dockerIndex  = "index.docker.io"
 )
 
-func getEncodedRegistryAuth(regHost string) (string, error) {
+// GetImageAuthConfig checks for local docker configuration and extracts registry authorization information for an image
+// if it exists.
+func GetImageAuthConfig(image string) (*types.AuthConfig, error) {
 	cfg, err := config.Load(config.Dir())
 	if err != nil {
-		return "", errors.Wrap(err, "could not load docker config")
+		return nil, errors.Wrap(err, "could not load docker config")
 	}
 
-	auth, err := cfg.GetAuthConfig(norm(regHost))
+	host, err := indexHostFromImage(image)
 	if err != nil {
-		return "", errors.Wrap(err, "could not load auth from docker config")
+		return nil, errors.Wrap(err, "could not extract domain from image")
+	}
+
+	auth, err := cfg.GetAuthConfig(host)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not obtain auth config")
+	}
+
+	return &types.AuthConfig{
+		Username:      auth.Username,
+		Password:      auth.Password,
+		Auth:          auth.Auth,
+		Email:         auth.Email,
+		ServerAddress: auth.ServerAddress,
+		IdentityToken: auth.IdentityToken,
+		RegistryToken: auth.RegistryToken,
+	}, nil
+
+}
+
+func getEncodedRegistryAuth(image string) (string, error) {
+	auth, err := GetImageAuthConfig(image)
+	if err != nil {
+		return "", err
 	}
 
 	jsonAuth, err := json.Marshal(auth)
@@ -33,11 +60,18 @@ func getEncodedRegistryAuth(regHost string) (string, error) {
 	return base64.URLEncoding.EncodeToString(jsonAuth), nil
 }
 
-func norm(regHost string) string {
-	if isHostOfficial(regHost) {
-		return dockerIndex
+func indexHostFromImage(img string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(img)
+	if err != nil {
+		return "", err
 	}
-	return regHost
+
+	domain := reference.Domain(named)
+	if isHostOfficial(domain) {
+		return dockerIndex, nil
+	}
+
+	return reference.Domain(named), nil
 }
 
 func isHostOfficial(regHost string) bool {

--- a/internal/docker/auth_integration_test.go
+++ b/internal/docker/auth_integration_test.go
@@ -31,6 +31,7 @@ func Test_getEncodedRegistryAuth(t *testing.T) {
 	var auth types.AuthConfig
 	err = json.Unmarshal(b, &auth)
 	require.Nil(t, err)
+	t.Logf("%+v\n", auth)
 	require.Equal(t, expectedUser, auth.Username)
 	require.Equal(t, expectedPwd, auth.Password)
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -55,14 +55,6 @@ type BuildResponse struct {
 	Procfile string
 }
 
-func domain(img string) (string, error) {
-	named, err := reference.ParseNormalizedNamed(img)
-	if err != nil {
-		return "", err
-	}
-	return reference.Domain(named), nil
-}
-
 // NormalizeImage will convert an image into a fully qualified form with the registry host and a tag.
 func NormalizeImage(imageURI string) (string, error) {
 	named, err := reference.ParseNormalizedNamed(imageURI)
@@ -96,11 +88,7 @@ func New() (*Client, error) {
 			return base64.URLEncoding.EncodeToString(jsonAuth), nil
 		}
 
-		repo, err := domain(req.Image)
-		if err != nil {
-			return "", err
-		}
-		encodedAuth, err := getEncodedRegistryAuth(repo)
+		encodedAuth, err := getEncodedRegistryAuth(req.Image)
 		if err != nil {
 			return "", err
 		}

--- a/internal/docker/secret.go
+++ b/internal/docker/secret.go
@@ -1,0 +1,140 @@
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/docker/docker/api/types"
+	v1 "k8s.io/api/core/v1"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type authConfigFn func(image string) (*types.AuthConfig, error)
+
+type secretGenerator struct {
+	authConfig authConfigFn
+}
+
+func GenerateSecret(image, namespace string) (*v1.Secret, error) {
+	gen := secretGenerator{
+		authConfig: GetImageAuthConfig,
+	}
+	return gen.generate(image, namespace)
+
+}
+
+func (sg secretGenerator) generate(image, namespace string) (*v1.Secret, error) {
+	auth, err := sg.authConfig(image)
+	if err != nil {
+		return nil, err
+	}
+
+	var secret v1.Secret
+	pName, err := makeK8sName(auth.Username, auth.ServerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	secret.Name = *pName
+	secret.Namespace = namespace
+	secret.Type = v1.SecretTypeDockerConfigJson
+	secret.Data = map[string][]byte{}
+
+	entry := ConfigEntry{
+		Username: auth.Username,
+		Password: auth.Password,
+		Email:    auth.Email,
+		Auth:     base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password)),
+	}
+
+	conf := ConfigJSON{
+		Auths: map[string]ConfigEntry{auth.ServerAddress: entry},
+	}
+
+	jsonContent, err := json.Marshal(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	secret.Data[v1.DockerConfigJsonKey] = jsonContent
+	return &secret, nil
+}
+
+type ConfigEntry struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+}
+
+type ConfigJSON struct {
+	Auths       map[string]ConfigEntry `json:"auths"`
+	HttpHeaders map[string]string      `json:"HttpHeaders,omitempty"`
+}
+
+type nameError string
+
+func (ne nameError) Error() string { return string(ne) }
+
+const (
+	maxNameLength = 253
+	minNameLength = 6
+	spaceChar     = 32
+	escapeChar    = 126
+
+	errNonPrintableCharacter nameError = "can't use non-printable character to generate secret name"
+	errNameTooLong           nameError = "name exceeds maximum length"
+	errNameTooShort          nameError = "name must be at least six characters"
+)
+
+// Create a name that can be used for k8s resources conforming to
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+// Note that the name we produce is repeatable, the same inputs yield the same output. Therefore, if
+// the length of the parts is too long, we return an error. We could truncate and return the name, but there
+// would be no way to compare too names because we wouldn't have access to the removed characters.
+func makeK8sName(parts ...string) (*string, error) {
+	var builder strings.Builder
+	builder.Grow(maxNameLength * 2)
+
+	sort.Strings(parts)
+
+	for _, part := range parts {
+		if err := mapBytesToLegalNameChars(&builder, part); err != nil {
+			return nil, err
+		}
+		if builder.Len() > maxNameLength {
+			return nil, errNameTooLong
+		}
+	}
+
+	if builder.Len() < minNameLength {
+		return nil, errNameTooShort
+	}
+	result := builder.String()
+	return &result, nil
+}
+
+func mapBytesToLegalNameChars(builder *strings.Builder, s string) error {
+	for _, b := range []byte(s) {
+		if !isPrintable(b) {
+			return errNonPrintableCharacter
+		}
+		switch {
+		case b >= 'a' && b <= 'z':
+			builder.WriteByte(b)
+		case b >= 'A' && b <= 'Z':
+			builder.WriteByte(b | 32)
+		case b >= '0' && b <= '9':
+			builder.WriteByte(b)
+		default:
+			builder.WriteString(strconv.FormatUint(uint64(b), 16))
+		}
+	}
+
+	return nil
+}
+
+func isPrintable(b byte) bool {
+	return b >= spaceChar && b <= escapeChar
+}

--- a/internal/docker/secret_test.go
+++ b/internal/docker/secret_test.go
@@ -1,0 +1,65 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_makeK8sName(t *testing.T) {
+	tt := []struct {
+		name     string
+		in       []string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "happy path",
+			in: []string{
+				"oNe.",
+				"zip",
+			},
+			expected: "one2ezip",
+		},
+		{
+			name: "invalid char",
+			in: []string{
+				"weird©Name",
+				"foöo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "too long",
+			in: []string{
+				func() string {
+					var b strings.Builder
+					for i := 0; i <= maxNameLength; i++ {
+						b.WriteByte('x')
+					}
+					return b.String()
+				}(),
+				"x.x",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ps, err := makeK8sName(tc.in...)
+			if tc.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+			require.Nil(t, err)
+			require.Equal(t, *ps, tc.expected)
+		})
+	}
+
+}


### PR DESCRIPTION
# Description

This is a proof of concept intended to demonstrate using Docker CLI credentials to create a k8s secret used to deploy an app with a private image. 
