### PR TITLE
[SHIPA-1131] Fix app deploy for minimal images

### DIFF
--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -145,7 +145,7 @@ func New(application *ketchv1.App, pool *ketchv1.Pool, opts ...Option) (*Applica
 			return nil, err
 		}
 		exposedPorts := options.ExposedPorts[deployment.Version]
-		c := NewConfigurator(deploymentSpec.KetchYaml, *procfile, exposedPorts, DefaultApplicationPort)
+		c := NewConfigurator(deploymentSpec.KetchYaml, *procfile, exposedPorts, DefaultApplicationPort, application.Spec.Platform)
 		for _, processSpec := range deploymentSpec.Processes {
 			name := processSpec.Name
 			isRoutable := procfile.IsRoutable(name)

--- a/internal/chart/application_chart_test.go
+++ b/internal/chart/application_chart_test.go
@@ -55,6 +55,7 @@ func TestNew(t *testing.T) {
 			Name: "dashboard",
 		},
 		Spec: ketchv1.AppSpec{
+			Platform: "static",
 			Deployments: []ketchv1.AppDeploymentSpec{
 				{
 					Image:   "shipasoftware/go-app:v1",

--- a/internal/chart/configurator_test.go
+++ b/internal/chart/configurator_test.go
@@ -14,6 +14,7 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 		procfile Procfile
 		process  string
 		want     []string
+		platform string
 	}{
 		{
 			name: "single command without changing working directory",
@@ -22,8 +23,9 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 					"web": {"python web.py"},
 				},
 			},
-			process: "web",
-			want:    []string{"/bin/sh", "-lc", "exec python web.py"},
+			process:  "web",
+			want:     []string{"/bin/sh", "-lc", "exec python web.py"},
+			platform: "python",
 		},
 		{
 			name: "single command",
@@ -32,8 +34,9 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 					"web": {"python web.py"},
 				},
 			},
-			process: "web",
-			want:    []string{"/bin/sh", "-lc", "exec python web.py"},
+			process:  "web",
+			want:     []string{"/bin/sh", "-lc", "exec python web.py"},
+			platform: "python",
 		},
 		{
 			name: "single command with hooks",
@@ -51,8 +54,9 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 					"web": {"python web.py"},
 				},
 			},
-			process: "web",
-			want:    []string{"/bin/sh", "-lc", "cmd1 && cmd2 && exec python web.py"},
+			process:  "web",
+			want:     []string{"/bin/sh", "-lc", "cmd1 && cmd2 && exec python web.py"},
+			platform: "python",
 		},
 		{
 			name: "single command with hooks, without changing working directory",
@@ -70,8 +74,9 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 					"web": {"python web.py"},
 				},
 			},
-			process: "web",
-			want:    []string{"/bin/sh", "-lc", "cmd1 && cmd2 && exec python web.py"},
+			process:  "web",
+			want:     []string{"/bin/sh", "-lc", "cmd1 && cmd2 && exec python web.py"},
+			platform: "python",
 		},
 		{
 			name: "many commands",
@@ -80,8 +85,9 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 					"web": {"python", "web.py"},
 				},
 			},
-			process: "web",
-			want:    []string{"/bin/sh", "-lc", "exec $0 \"$@\"", "python", "web.py"},
+			process:  "web",
+			want:     []string{"/bin/sh", "-lc", "exec $0 \"$@\"", "python", "web.py"},
+			platform: "python",
 		},
 	}
 	for _, tt := range tests {
@@ -89,6 +95,7 @@ func TestKubernetesConfigurator_ProcessCmd(t *testing.T) {
 			conf := Configurator{
 				data:     tt.data,
 				procfile: tt.procfile,
+				platform: tt.platform,
 			}
 			if got := conf.ProcessCmd(tt.process); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ProcessCmd() = %v, want %v", got, tt.want)


### PR DESCRIPTION
# Description

Minimal images do not have a shell and this breaks the pod command construction which requires a shell for build hooks.  This is fixed by skipping this step if there is not a platform defined. 

Fixes Subtask [shipa-1131](https://shipaio.atlassian.net/browse/SHIPA-1131)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
