### PR TITLE
Readme - reverts PR #99 and framework references

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,21 +79,24 @@ Thats it!
 Learn more about Ketch at [Ketch documentation](https://learn.theketch.io/docs)
 
 ### Quick Start
-Deploying apps is easy once you've installed Ketch.  First, create a framework. Then create app(s) adding them to the framework and finally
+Deploying apps is easy once you've installed Ketch.  First, create a pool. Then create app(s) adding them to the pool and finally
 deploy the app(s).  The following example illustrates these steps.
 
 ```bash
-# Add a framework with ingress Traefik (default), replace ingress IP address by your ingress IP address
-ketch framework add myframework  --ingress-service-endpoint 35.247.8.23 --ingress-type traefik
+# Add a pool with ingress Traefik (default), replace ingress IP address by your ingress IP address
+ketch pool add mypool  --ingress-service-endpoint 35.247.8.23 --ingress-type traefik
 
-# Create and deploy an application
-ketch app deploy bulletinboard --framework myframework -i docker.io/shipasoftware/bulletinboard:1.0
+# Create app
+ketch app create bulletinboard --pool mypool
+
+# Deploy app
+ketch app deploy bulletinboard -i docker.io/shipasoftware/bulletinboard:1.0
 
 # Check app status
 ketch app list
 
-NAME             FRAMEWORK        STATE        ADDRESSES                                      PLATFORM    DESCRIPTION
-bulletinboard    myframework      1 running    http://bulletinboard.35.247.8.23.shipa.cloud
+NAME             POOL        STATE        ADDRESSES                                      PLATFORM    DESCRIPTION
+bulletinboard    mypool      1 running    http://bulletinboard.35.247.8.23.shipa.cloud
 ```
 After you deploy your application, you can access it at the address associated with it using the `ketch app list`, in
 this example `bulletinboard.35.247.8.23.shipa.cloud`.
@@ -112,7 +115,7 @@ Available Commands:
   env         Manage an app's environment variables
   help        Help about any command
   platform    Manage platforms
-  framework        Manage frameworks
+  pool        Manage pool
   unit        Manage an app's units
 
 Flags:


### PR DESCRIPTION
# Description

In [this Slack discussion](https://shipa-io.slack.com/archives/CS3KL4BK7/p1623836244412000), we decided that the README should reference the latest stable release (0.2.1), which precedes 1) the merging of `create` and `deploy` commands and the renaming of `pool` to `framework`. This small PR reverts a couple changes made that reference non-stable-release features. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
