### PR TITLE
Shipa 1461 set default builder

### DIFF
--- a/cmd/ketch/app.go
+++ b/cmd/ketch/app.go
@@ -14,7 +14,7 @@ import (
 	"github.com/shipa-corp/ketch/internal/pack"
 )
 
-func newAppCmd(cfg config, out io.Writer, packSvc *pack.Client) *cobra.Command {
+func newAppCmd(cfg config, out io.Writer, packSvc *pack.Client, configDefaultBuilder string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "app",
 		Short: "Manage applications",
@@ -33,7 +33,7 @@ func newAppCmd(cfg config, out io.Writer, packSvc *pack.Client) *cobra.Command {
 		Writer:         out,
 	}
 
-	cmd.AddCommand(newAppDeployCmd(params))
+	cmd.AddCommand(newAppDeployCmd(params, configDefaultBuilder))
 	cmd.AddCommand(newAppListCmd(cfg, out))
 	cmd.AddCommand(newAppLogCmd(cfg, out, appLog))
 	cmd.AddCommand(newAppRemoveCmd(cfg, out, appRemove))

--- a/cmd/ketch/app_deploy.go
+++ b/cmd/ketch/app_deploy.go
@@ -26,7 +26,7 @@ Deploy from an image:
 )
 
 // NewCommand creates a command that will run the app deploy
-func newAppDeployCmd(params *deploy.Services) *cobra.Command {
+func newAppDeployCmd(params *deploy.Services, configDefaultBuilder string) *cobra.Command {
 	var options deploy.Options
 
 	cmd := &cobra.Command{
@@ -38,6 +38,9 @@ func newAppDeployCmd(params *deploy.Services) *cobra.Command {
 			options.AppName = args[0]
 			if len(args) == 2 {
 				options.AppSourcePath = args[1]
+			}
+			if configDefaultBuilder != "" {
+				deploy.DefaultBuilder = configDefaultBuilder
 			}
 			return deploy.New(options.GetChangeSet(cmd.Flags())).Run(cmd.Context(), params)
 		},

--- a/cmd/ketch/app_deploy_test.go
+++ b/cmd/ketch/app_deploy_test.go
@@ -148,12 +148,13 @@ kubernetes:
 
 func TestNewCommand(t *testing.T) {
 	tt := []struct {
-		name      string
-		params    *deploy.Services
-		arguments []string
-		setup     func(t *testing.T)
-		validate  func(t *testing.T, m deploy.Client)
-		wantError bool
+		name        string
+		params      *deploy.Services
+		arguments   []string
+		setup       func(t *testing.T)
+		userDefault string
+		validate    func(t *testing.T, m deploy.Client)
+		wantError   bool
 	}{
 		{
 			name: "change builder from previous deploy",
@@ -243,6 +244,84 @@ func TestNewCommand(t *testing.T) {
 					}
 					return m
 				}(),
+				KubeClient:     fake.NewSimpleClientset(),
+				Builder:        build.GetSourceHandler(&packMocker{}),
+				GetImageConfig: getImageConfig,
+				Wait:           nil,
+				Writer:         &bytes.Buffer{},
+			},
+		},
+		{
+			name: "use user default builder for new app",
+			arguments: []string{
+				"myapp",
+				"src",
+				"--framework", "myframework",
+				"--image", "shipa/go-sample:latest",
+			},
+			setup: func(t *testing.T) {
+				dir := t.TempDir()
+				require.Nil(t, os.Mkdir(path.Join(dir, "src"), 0700))
+				require.Nil(t, os.Chdir(dir))
+			},
+			userDefault: "newDefault",
+			validate: func(t *testing.T, m deploy.Client) {
+				mock, ok := m.(*mockClient)
+				require.True(t, ok)
+				require.Equal(t, "newDefault", mock.app.Spec.Builder)
+			},
+			params: &deploy.Services{
+				Client: func() *mockClient {
+					m := newMockClient()
+					m.get[1] = func(_ *mockClient, _ runtime.Object) error {
+						return errors.NewNotFound(v1.Resource(""), "")
+					}
+					return m
+				}(),
+				KubeClient:     fake.NewSimpleClientset(),
+				Builder:        build.GetSourceHandler(&packMocker{}),
+				GetImageConfig: getImageConfig,
+				Wait:           nil,
+				Writer:         &bytes.Buffer{},
+			},
+		},
+		{
+			name: "don't update builder on previous deployment",
+			arguments: []string{
+				"myapp",
+				"src",
+				"--image", "shipa/go-sample:latest",
+			},
+			setup: func(t *testing.T) {
+				dir := t.TempDir()
+				require.Nil(t, os.Mkdir(path.Join(dir, "src"), 0700))
+				require.Nil(t, os.Chdir(dir))
+			},
+			userDefault: "newDefault",
+			validate: func(t *testing.T, m deploy.Client) {
+				mock, ok := m.(*mockClient)
+				require.True(t, ok)
+				require.Equal(t, mock.app.Spec.Builder, "initialBuilder")
+
+			},
+			params: &deploy.Services{
+				Client: func() *mockClient {
+					m := newMockClient()
+					m.app.Spec.Builder = "initialBuilder"
+					m.app.Spec.Deployments = []ketchv1.AppDeploymentSpec{
+						{
+							Image:           "shipa/go-sample:latest",
+							Version:         1,
+							Processes:       nil,
+							KetchYaml:       nil,
+							Labels:          nil,
+							RoutingSettings: ketchv1.RoutingSettings{},
+							ExposedPorts:    nil,
+						},
+					}
+					return m
+				}(),
+
 				KubeClient:     fake.NewSimpleClientset(),
 				Builder:        build.GetSourceHandler(&packMocker{}),
 				GetImageConfig: getImageConfig,
@@ -546,7 +625,7 @@ func TestNewCommand(t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(t)
 			}
-			cmd := newAppDeployCmd(tc.params, "")
+			cmd := newAppDeployCmd(tc.params, tc.userDefault)
 			cmd.SetArgs(tc.arguments)
 			err = cmd.Execute()
 			if tc.wantError {

--- a/cmd/ketch/app_deploy_test.go
+++ b/cmd/ketch/app_deploy_test.go
@@ -546,7 +546,7 @@ func TestNewCommand(t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(t)
 			}
-			cmd := newAppDeployCmd(tc.params)
+			cmd := newAppDeployCmd(tc.params, "")
 			cmd.SetArgs(tc.arguments)
 			err = cmd.Execute()
 			if tc.wantError {

--- a/cmd/ketch/builder.go
+++ b/cmd/ketch/builder.go
@@ -26,5 +26,6 @@ func newBuilderCmd(ketchConfig configuration.KetchConfig, out io.Writer) *cobra.
 	}
 
 	cmd.AddCommand(newBuilderListCmd(ketchConfig, out))
+	cmd.AddCommand(newBuilderSetCmd(ketchConfig))
 	return cmd
 }

--- a/cmd/ketch/builder_set.go
+++ b/cmd/ketch/builder_set.go
@@ -23,8 +23,8 @@ func newBuilderSetCmd(ketchConfig configuration.KetchConfig) *cobra.Command {
 	return cmd
 }
 
-func setDefaultBuilder(ketchConfig configuration.KetchConfig, defaultBulder string) error {
-	ketchConfig.DefaultBuilder = defaultBulder
+func setDefaultBuilder(ketchConfig configuration.KetchConfig, defaultBuilder string) error {
+	ketchConfig.DefaultBuilder = defaultBuilder
 	path, err := configuration.DefaultConfigPath()
 	if err != nil {
 		return err

--- a/cmd/ketch/builder_set.go
+++ b/cmd/ketch/builder_set.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/shipa-corp/ketch/cmd/ketch/configuration"
+)
+
+const builderSetHelp = `
+Manage the default builder to be used when deploying from source. This value can also be set manually in the config.toml
+by specifying "default-builder".`
+
+func newBuilderSetCmd(ketchConfig configuration.KetchConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "set default builder",
+		Long:  builderSetHelp,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setDefaultBuilder(ketchConfig, args[0])
+		},
+	}
+	return cmd
+}
+
+func setDefaultBuilder(ketchConfig configuration.KetchConfig, defaultBulder string) error {
+	ketchConfig.DefaultBuilder = defaultBulder
+	path, err := configuration.DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+	return configuration.Write(ketchConfig, path)
+}

--- a/cmd/ketch/builder_set_test.go
+++ b/cmd/ketch/builder_set_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shipa-corp/ketch/cmd/ketch/configuration"
+)
+
+func Test_newBuilderSetCmd(t *testing.T) {
+	type args struct {
+		ketchConfig   configuration.KetchConfig
+		defaultBulder string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "successfully write to file",
+			args: args{
+				ketchConfig: configuration.KetchConfig{
+					DefaultBuilder: "oldDefault",
+				},
+				defaultBulder: "newDefault",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootPath := t.TempDir()
+			fullPath := filepath.Join(rootPath, "config.toml")
+			os.Setenv("KETCH_HOME", rootPath)
+
+			cmd := newBuilderSetCmd(tt.args.ketchConfig)
+			cmd.SetArgs([]string{tt.args.defaultBulder})
+			err := cmd.Execute()
+			require.Nil(t, err)
+
+			var ketchConfig configuration.KetchConfig
+			_, err = toml.DecodeFile(fullPath, &ketchConfig)
+			require.Nil(t, err)
+
+			require.Equal(t, tt.args.defaultBulder, ketchConfig.DefaultBuilder)
+		})
+	}
+}

--- a/cmd/ketch/configuration/configuration.go
+++ b/cmd/ketch/configuration/configuration.go
@@ -37,6 +37,7 @@ type Configuration struct {
 // KetchConfig contains all the values present in the config.toml
 type KetchConfig struct {
 	AdditionalBuilders []AdditionalBuilder `toml:"additional-builders,omitempty"`
+	DefaultBuilder     string              `toml:"default-builder,omitempty"`
 }
 
 // AdditionalBuilder contains the information of any user added builders
@@ -133,4 +134,17 @@ func Read(path string) KetchConfig {
 		return KetchConfig{}
 	}
 	return ketchConfig
+}
+
+func Write(ketchConfig KetchConfig, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return err
+	}
+	w, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	return toml.NewEncoder(w).Encode(ketchConfig)
 }

--- a/cmd/ketch/configuration/configuration.go
+++ b/cmd/ketch/configuration/configuration.go
@@ -136,6 +136,7 @@ func Read(path string) KetchConfig {
 	return ketchConfig
 }
 
+//Write writes the provided KetchConfig to the given path. In the event the path is not found it will be created
 func Write(ketchConfig KetchConfig, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return err

--- a/cmd/ketch/root.go
+++ b/cmd/ketch/root.go
@@ -57,7 +57,7 @@ func newRootCmd(cfg config, out io.Writer, packSvc *pack.Client, ketchConfig con
 			return cmd.Usage()
 		},
 	}
-	cmd.AddCommand(newAppCmd(cfg, out, packSvc))
+	cmd.AddCommand(newAppCmd(cfg, out, packSvc, ketchConfig.DefaultBuilder))
 	cmd.AddCommand(newBuilderCmd(ketchConfig, out))
 	cmd.AddCommand(newCnameCmd(cfg, out))
 	cmd.AddCommand(newFrameworkCmd(cfg, out))

--- a/internal/deploy/parameters.go
+++ b/internal/deploy/parameters.go
@@ -42,9 +42,11 @@ const (
 	FlagEnvironmentShort = "e"
 	FlagFrameworkShort   = "k"
 
-	DefaultBuilder = "heroku/buildpacks:20"
-
 	defaultYamlFile = "ketch.yaml"
+)
+
+var (
+	DefaultBuilder = "heroku/buildpacks:20"
 )
 
 // Services contains interfaces and function pointers to external services needed for deploy. The purpose of this


### PR DESCRIPTION
# Description

Allow for the user to set their own default builder to be used whenever a new application is created from source. The name of the builder is persisted via a config.toml. The default location of the config.toml is expected to be `~/.ketch/`, but this can be overwritten by exporting the path to config.toml as `KETCH_HOME`

Fixes #1461

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
