### PR TITLE
adds app yaml

### DIFF
--- a/cmd/ketch/app_deploy.go
+++ b/cmd/ketch/app_deploy.go
@@ -25,6 +25,10 @@ Details about Procfile conventions can be found here: https://devcenter.heroku.c
 Deploy from an image:
   ketch app deploy <app name> -i myregistry/myimage:latest
 
+Users can deploy from image or source code by passing a filename such as app.yaml containing fields like:
+	name: test
+	image: gcr.io/shipa-ci/sample-go-app:latest
+	framework: myframework
 `
 )
 
@@ -33,7 +37,7 @@ func newAppDeployCmd(cfg config, params *deploy.Services, configDefaultBuilder s
 	var options deploy.Options
 
 	cmd := &cobra.Command{
-		Use:   "deploy APPNAME [SOURCE DIRECTORY]",
+		Use:   "deploy [APPNAME|FILENAME] [SOURCE DIRECTORY]",
 		Short: "Deploy an app.",
 		Long:  appDeployHelp,
 		Args:  cobra.RangeArgs(1, 2),

--- a/cmd/ketch/app_deploy.go
+++ b/cmd/ketch/app_deploy.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"github.com/shipa-corp/ketch/internal/validation"
-
 	"github.com/spf13/cobra"
 
 	"github.com/shipa-corp/ketch/internal/deploy"
+	"github.com/shipa-corp/ketch/internal/validation"
 )
 
 const (

--- a/cmd/ketch/app_info.go
+++ b/cmd/ketch/app_info.go
@@ -22,6 +22,9 @@ import (
 var (
 	appInfoTemplate = `Application: {{ .App.Name }}
 Framework: {{ .App.Spec.Framework }}
+{{- if .App.Spec.Version }}
+Version: {{ .App.Spec.Version }}
+{{- end }}
 {{- if .App.Spec.Builder }}
 Builder: {{ .App.Spec.Builder }}
 {{- end }}

--- a/cmd/ketch/framework_add_test.go
+++ b/cmd/ketch/framework_add_test.go
@@ -17,7 +17,7 @@ import (
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/mocks"
-	"github.com/shipa-corp/ketch/internal/testutils"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func Test_addFramework(t *testing.T) {
@@ -64,7 +64,7 @@ ingressController:
 				Name:          "hello",
 				Version:       "v1",
 				NamespaceName: "ketch-hello",
-				AppQuotaLimit: testutils.IntPtr(-1),
+				AppQuotaLimit: conversions.IntPtr(-1),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "istio",
 					ServiceEndpoint: "10.10.20.30",
@@ -107,7 +107,7 @@ ingressController:
 			},
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "gke",
-				AppQuotaLimit: testutils.IntPtr(5),
+				AppQuotaLimit: conversions.IntPtr(5),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "istio",
 					ServiceEndpoint: "10.10.20.30",
@@ -136,7 +136,7 @@ ingressController:
 			},
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "gke",
-				AppQuotaLimit: testutils.IntPtr(5),
+				AppQuotaLimit: conversions.IntPtr(5),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "custom-class-name",
 					ServiceEndpoint: "10.10.20.30",
@@ -161,7 +161,7 @@ ingressController:
 			},
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "ketch-aws",
-				AppQuotaLimit: testutils.IntPtr(5),
+				AppQuotaLimit: conversions.IntPtr(5),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "traefik",
 					ServiceEndpoint: "10.10.10.10",
@@ -280,7 +280,7 @@ ingressController:
 					Version:       "v1",
 					Name:          "hello",
 					NamespaceName: "my-namespace",
-					AppQuotaLimit: testutils.IntPtr(5),
+					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType:     "istio",
 						ServiceEndpoint: "10.10.20.30",
@@ -313,7 +313,7 @@ ingressController:
 					Version:       "v1",
 					Name:          "hello",
 					NamespaceName: "ketch-hello",
-					AppQuotaLimit: testutils.IntPtr(-1),
+					AppQuotaLimit: conversions.IntPtr(-1),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType: "traefik",
 						ClassName:   "traefik",
@@ -368,7 +368,7 @@ func TestNewFrameworkFromArgs(t *testing.T) {
 				},
 				Spec: ketchv1.FrameworkSpec{
 					NamespaceName: "my-namespace",
-					AppQuotaLimit: testutils.IntPtr(5),
+					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType:     "istio",
 						ServiceEndpoint: "10.10.20.30",
@@ -390,7 +390,7 @@ func TestNewFrameworkFromArgs(t *testing.T) {
 				},
 				Spec: ketchv1.FrameworkSpec{
 					NamespaceName: "ketch-hello",
-					AppQuotaLimit: testutils.IntPtr(5),
+					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType: "traefik",
 						ClassName:   "traefik",

--- a/cmd/ketch/framework_export_test.go
+++ b/cmd/ketch/framework_export_test.go
@@ -11,7 +11,7 @@ import (
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/mocks"
-	"github.com/shipa-corp/ketch/internal/testutils"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func TestExportFramework(t *testing.T) {
@@ -19,7 +19,7 @@ func TestExportFramework(t *testing.T) {
 		Version:       "v1",
 		NamespaceName: "ketch-myframework",
 		Name:          "myframework",
-		AppQuotaLimit: testutils.IntPtr(1),
+		AppQuotaLimit: conversions.IntPtr(1),
 		IngressController: ketchv1.IngressControllerSpec{
 			ClassName:       "traefik",
 			ServiceEndpoint: "10.10.20.30",

--- a/cmd/ketch/framework_list_test.go
+++ b/cmd/ketch/framework_list_test.go
@@ -6,13 +6,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shipa-corp/ketch/internal/testutils"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/mocks"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func Test_frameworkList(t *testing.T) {
@@ -23,7 +22,7 @@ func Test_frameworkList(t *testing.T) {
 		},
 		Spec: ketchv1.FrameworkSpec{
 			NamespaceName: "a",
-			AppQuotaLimit: testutils.IntPtr(30),
+			AppQuotaLimit: conversions.IntPtr(30),
 			IngressController: ketchv1.IngressControllerSpec{
 				ClassName:       "istio",
 				ServiceEndpoint: "192.168.1.17",
@@ -39,7 +38,7 @@ func Test_frameworkList(t *testing.T) {
 		},
 		Spec: ketchv1.FrameworkSpec{
 			NamespaceName: "b",
-			AppQuotaLimit: testutils.IntPtr(30),
+			AppQuotaLimit: conversions.IntPtr(30),
 			IngressController: ketchv1.IngressControllerSpec{
 				ClassName:       "classname-b",
 				ServiceEndpoint: "192.168.1.17",

--- a/cmd/ketch/framework_update_test.go
+++ b/cmd/ketch/framework_update_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/shipa-corp/ketch/internal/testutils"
-
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -16,6 +14,7 @@ import (
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/mocks"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func Test_frameworkUpdate(t *testing.T) {
@@ -50,7 +49,7 @@ func Test_frameworkUpdate(t *testing.T) {
 		},
 		Spec: ketchv1.FrameworkSpec{
 			NamespaceName: "frontend",
-			AppQuotaLimit: testutils.IntPtr(30),
+			AppQuotaLimit: conversions.IntPtr(30),
 			IngressController: ketchv1.IngressControllerSpec{
 				ClassName:       "default-classname",
 				ServiceEndpoint: "192.168.1.17",
@@ -92,7 +91,7 @@ ingressController:
 				Name:          "frontend-framework",
 				Version:       "v1",
 				NamespaceName: "ketch-frontend-framework",
-				AppQuotaLimit: testutils.IntPtr(30),
+				AppQuotaLimit: conversions.IntPtr(30),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "default-classname",
 					ServiceEndpoint: "192.168.1.18",
@@ -116,7 +115,7 @@ ingressController:
 			wantOut: "Successfully updated!\n",
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "frontend",
-				AppQuotaLimit: testutils.IntPtr(30),
+				AppQuotaLimit: conversions.IntPtr(30),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "default-classname",
 					ServiceEndpoint: "192.168.1.18",
@@ -140,7 +139,7 @@ ingressController:
 			wantOut: "Successfully updated!\n",
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "frontend",
-				AppQuotaLimit: testutils.IntPtr(30),
+				AppQuotaLimit: conversions.IntPtr(30),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "traefik",
 					ServiceEndpoint: "192.168.1.17",
@@ -164,7 +163,7 @@ ingressController:
 			wantOut: "Successfully updated!\n",
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "new-namespace",
-				AppQuotaLimit: testutils.IntPtr(30),
+				AppQuotaLimit: conversions.IntPtr(30),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "default-classname",
 					ServiceEndpoint: "192.168.1.17",
@@ -188,7 +187,7 @@ ingressController:
 			wantOut: "Successfully updated!\n",
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "frontend",
-				AppQuotaLimit: testutils.IntPtr(50),
+				AppQuotaLimit: conversions.IntPtr(50),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "default-classname",
 					ServiceEndpoint: "192.168.1.17",
@@ -212,7 +211,7 @@ ingressController:
 			wantOut: "Successfully updated!\n",
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "frontend",
-				AppQuotaLimit: testutils.IntPtr(30),
+				AppQuotaLimit: conversions.IntPtr(30),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "default-classname",
 					ServiceEndpoint: "192.168.1.17",
@@ -236,7 +235,7 @@ ingressController:
 			wantOut: "Successfully updated!\n",
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
 				NamespaceName: "frontend",
-				AppQuotaLimit: testutils.IntPtr(30),
+				AppQuotaLimit: conversions.IntPtr(30),
 				IngressController: ketchv1.IngressControllerSpec{
 					ClassName:       "default-classname",
 					ServiceEndpoint: "192.168.1.17",
@@ -308,7 +307,7 @@ func TestUpdateFrameworkFromYaml(t *testing.T) {
 		},
 		Spec: ketchv1.FrameworkSpec{
 			NamespaceName: "frontend",
-			AppQuotaLimit: testutils.IntPtr(30),
+			AppQuotaLimit: conversions.IntPtr(30),
 			IngressController: ketchv1.IngressControllerSpec{
 				ClassName:       "default-classname",
 				ServiceEndpoint: "192.168.1.17",
@@ -350,7 +349,7 @@ ingressController:
 					Version:       "v1",
 					Name:          "frontend-framework",
 					NamespaceName: "my-namespace",
-					AppQuotaLimit: testutils.IntPtr(5),
+					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType:     "traefik",
 						ServiceEndpoint: "192.168.1.18",
@@ -379,7 +378,7 @@ ingressController:
 					Version:       "v1",
 					Name:          "frontend-framework",
 					NamespaceName: "ketch-frontend-framework",
-					AppQuotaLimit: testutils.IntPtr(-1),
+					AppQuotaLimit: conversions.IntPtr(-1),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType: "traefik",
 						ClassName:   "traefik",
@@ -414,7 +413,7 @@ func TestUpdateFrameworkFromArgs(t *testing.T) {
 		},
 		Spec: ketchv1.FrameworkSpec{
 			NamespaceName: "frontend",
-			AppQuotaLimit: testutils.IntPtr(30),
+			AppQuotaLimit: conversions.IntPtr(30),
 			IngressController: ketchv1.IngressControllerSpec{
 				ClassName:       "default-classname",
 				ServiceEndpoint: "192.168.1.17",
@@ -459,7 +458,7 @@ func TestUpdateFrameworkFromArgs(t *testing.T) {
 				},
 				Spec: ketchv1.FrameworkSpec{
 					NamespaceName: "my-namespace",
-					AppQuotaLimit: testutils.IntPtr(5),
+					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType:     "istio",
 						ServiceEndpoint: "10.10.20.30",

--- a/internal/api/v1beta1/framework_webhook_test.go
+++ b/internal/api/v1beta1/framework_webhook_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/shipa-corp/ketch/internal/testutils"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/shipa-corp/ketch/internal/api/v1beta1/mocks"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func TestFramework_ValidateDelete(t *testing.T) {
@@ -170,7 +169,7 @@ func TestFramework_ValidateUpdate(t *testing.T) {
 			name: "everything is ok",
 			framework: Framework{
 				ObjectMeta: metav1.ObjectMeta{Name: "framework-1"},
-				Spec:       FrameworkSpec{NamespaceName: "ketch-namespace", AppQuotaLimit: testutils.IntPtr(2)},
+				Spec:       FrameworkSpec{NamespaceName: "ketch-namespace", AppQuotaLimit: conversions.IntPtr(2)},
 			},
 			client: &mocks.MockClient{
 				OnList: func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
@@ -190,7 +189,7 @@ func TestFramework_ValidateUpdate(t *testing.T) {
 			name: "failed to descrease quota",
 			framework: Framework{
 				ObjectMeta: metav1.ObjectMeta{Name: "framework-1"},
-				Spec:       FrameworkSpec{NamespaceName: "ketch-namespace", AppQuotaLimit: testutils.IntPtr(1)},
+				Spec:       FrameworkSpec{NamespaceName: "ketch-namespace", AppQuotaLimit: conversions.IntPtr(1)},
 				Status: FrameworkStatus{
 					Apps: []string{"app-1", "app-2"},
 				},
@@ -206,7 +205,7 @@ func TestFramework_ValidateUpdate(t *testing.T) {
 				},
 			},
 			old: &Framework{
-				Spec: FrameworkSpec{NamespaceName: "ketch-namespace", AppQuotaLimit: testutils.IntPtr(5)},
+				Spec: FrameworkSpec{NamespaceName: "ketch-namespace", AppQuotaLimit: conversions.IntPtr(5)},
 				Status: FrameworkStatus{
 					Apps: []string{"app-1", "app-2"},
 				},

--- a/internal/chart/procfile.go
+++ b/internal/chart/procfile.go
@@ -3,6 +3,8 @@ package chart
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -100,4 +102,19 @@ func routableProcess(names []string) string {
 	}
 	sort.Strings(names)
 	return names[0]
+}
+
+func WriteProcfile(processes []ketchv1.ProcessSpec, dest string) error {
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, process := range processes {
+		_, err = fmt.Fprintf(f, "%s: %s\n", process.Name, strings.Join(process.Cmd, " "))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/chart/procfile.go
+++ b/internal/chart/procfile.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	ErrEmptyProcfile = errors.New("procfile should contain at least one process name with a command")
+	ErrEmptyProcfile  = errors.New("procfile should contain at least one process name with a command")
+	ErrProcfileExists = errors.New("a Procfile already exists")
 
 	processNameRegex = regexp.MustCompile(`^([A-Za-z0-9_-]+)$`)
 )
@@ -117,4 +118,12 @@ func WriteProcfile(processes []ketchv1.ProcessSpec, dest string) error {
 		}
 	}
 	return nil
+}
+
+func AssertProcfileNotExist() error {
+	_, err := os.Lstat("Procfile")
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return ErrProcfileExists
 }

--- a/internal/controllers/app_controller_test.go
+++ b/internal/controllers/app_controller_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shipa-corp/ketch/internal/testutils"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/release"
@@ -20,6 +18,7 @@ import (
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/chart"
 	"github.com/shipa-corp/ketch/internal/templates"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func stringRef(s string) *string {
@@ -61,7 +60,7 @@ func TestAppReconciler_Reconcile(t *testing.T) {
 			},
 			Spec: ketchv1.FrameworkSpec{
 				NamespaceName: "hello",
-				AppQuotaLimit: testutils.IntPtr(100),
+				AppQuotaLimit: conversions.IntPtr(100),
 				IngressController: ketchv1.IngressControllerSpec{
 					IngressType: ketchv1.IstioIngressControllerType,
 				},
@@ -73,7 +72,7 @@ func TestAppReconciler_Reconcile(t *testing.T) {
 			},
 			Spec: ketchv1.FrameworkSpec{
 				NamespaceName: "second-namespace",
-				AppQuotaLimit: testutils.IntPtr(1),
+				AppQuotaLimit: conversions.IntPtr(1),
 				IngressController: ketchv1.IngressControllerSpec{
 					IngressType: ketchv1.IstioIngressControllerType,
 				},

--- a/internal/controllers/framework_controller_test.go
+++ b/internal/controllers/framework_controller_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shipa-corp/ketch/internal/testutils"
-
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func TestFrameworkReconciler_Reconcile(t *testing.T) {
@@ -25,7 +24,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 			},
 			Spec: ketchv1.FrameworkSpec{
 				NamespaceName: "default-namespace",
-				AppQuotaLimit: testutils.IntPtr(100),
+				AppQuotaLimit: conversions.IntPtr(100),
 				IngressController: ketchv1.IngressControllerSpec{
 					IngressType: ketchv1.IstioIngressControllerType,
 				},
@@ -50,7 +49,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 					Name: "framework-2",
 				},
 				Spec: ketchv1.FrameworkSpec{
-					AppQuotaLimit: testutils.IntPtr(1),
+					AppQuotaLimit: conversions.IntPtr(1),
 					NamespaceName: "default-namespace",
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType: ketchv1.IstioIngressControllerType,
@@ -67,7 +66,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 					Name: "framework-3",
 				},
 				Spec: ketchv1.FrameworkSpec{
-					AppQuotaLimit: testutils.IntPtr(1),
+					AppQuotaLimit: conversions.IntPtr(1),
 					NamespaceName: "another-namespace-3",
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType: ketchv1.IstioIngressControllerType,
@@ -86,7 +85,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 					Name: "framework-4",
 				},
 				Spec: ketchv1.FrameworkSpec{
-					AppQuotaLimit: testutils.IntPtr(1),
+					AppQuotaLimit: conversions.IntPtr(1),
 					NamespaceName: "another-namespace-4",
 					IngressController: ketchv1.IngressControllerSpec{
 						IngressType: ketchv1.TraefikIngressControllerType,

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -5,6 +5,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -220,6 +221,13 @@ func deployImage(ctx context.Context, svc *Services, app *ketchv1.App, params *C
 		sourcePath, _ := params.getSourceDirectory()
 		if err := buildFromSource(ctx, svc, app, params.appName, image, sourcePath); err != nil {
 			return errors.Wrap(err, "failed to build image from source path %q", sourcePath)
+		}
+		if params.processes != nil {
+			// clean up generated Procfile when built from source using yaml-specified processes
+			err = os.Remove("Procfile")
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -256,6 +256,7 @@ func deployImage(ctx context.Context, svc *Services, app *ketchv1.App, params *C
 	updateRequest.version = version
 	process, _ := params.getProcess()
 	updateRequest.process = process
+	updateRequest.processes = params.processes
 
 	if app, err = updateAppCRD(ctx, svc, params.appName, updateRequest); err != nil {
 		deploymentType := "image"
@@ -308,6 +309,7 @@ type updateAppCRDRequest struct {
 	units             int
 	version           int
 	process           string
+	processes         *[]ketchv1.ProcessSpec
 }
 
 func updateAppCRD(ctx context.Context, svc *Services, appName string, args updateAppCRDRequest) (*ketchv1.App, error) {

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -113,6 +113,10 @@ func getUpdatedApp(ctx context.Context, client Client, cs *ChangeSet) (*ketchv1.
 
 		if cs.sourcePath != nil {
 			if cs.processes != nil {
+				err = chart.AssertProcfileNotExist()
+				if err != nil {
+					return fmt.Errorf("%s: building from source writes specified processes to a Procfile in the project root", err.Error())
+				}
 				err = chart.WriteProcfile(*cs.processes, path.Join(*cs.sourcePath, defaultProcFile))
 				if err != nil {
 					return err

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -24,11 +24,10 @@ import (
 )
 
 const (
-	defaultTrafficWeight   = 100
-	minimumSteps           = 2
-	maximumSteps           = 100
-	defaultProcFile        = "Procfile"
-	defaultUnitsPerProcess = 1
+	defaultTrafficWeight = 100
+	minimumSteps         = 2
+	maximumSteps         = 100
+	defaultProcFile      = "Procfile"
 )
 
 // Client represents go sdk k8s client operations that we need.

--- a/internal/deploy/parameters.go
+++ b/internal/deploy/parameters.go
@@ -114,6 +114,12 @@ type ChangeSet struct {
 	dockerRegistrySecret *string
 	builder              *string
 	buildPacks           *[]string
+	appVersion           *string
+	appType              *string
+	appUnit              *int
+	processes            *[]ketchv1.ProcessSpec
+	ketchYamlData        *ketchv1.KetchYamlData
+	cname                *ketchv1.CnameList
 	units                *int
 	version              *int
 	process              *string
@@ -366,6 +372,9 @@ func (c *ChangeSet) getBuildPacks() ([]string, error) {
 }
 
 func (c *ChangeSet) getKetchYaml() (*ketchv1.KetchYamlData, error) {
+	if c.ketchYamlData != nil {
+		return c.ketchYamlData, nil
+	}
 	var fileName string
 	// try to find yaml file in default location
 	sourcePath, err := c.getSourceDirectory()
@@ -401,4 +410,8 @@ func (c *ChangeSet) getKetchYaml() (*ketchv1.KetchYamlData, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+func (c *ChangeSet) getAppUnit() int {
+	return *c.appUnit
 }

--- a/internal/deploy/yaml.go
+++ b/internal/deploy/yaml.go
@@ -14,19 +14,19 @@ import (
 // Application represents the fields in an application.yaml file that will be
 // transitioned to a ChangeSet.
 type Application struct {
-	Version        *string    `json:"version"`
-	Type           *string    `json:"type"`
-	Name           *string    `json:"name"`
-	Image          *string    `json:"image"`
-	Framework      *string    `json:"framework"`
-	Description    *string    `json:"description"`
-	Environment    *[]string  `json:"environment"`
-	RegistrySecret *string    `json:"registrySecret"`
-	Builder        *string    `json:"builder"`
-	BuildPacks     *[]string  `json:"buildPacks"`
-	Processes      *[]Process `json:"processes"`
-	CName          *CName     `json:"cname"`
-	AppUnit        *int       `json:"appUnit"`
+	Version        *string   `json:"version"`
+	Type           *string   `json:"type"`
+	Name           *string   `json:"name"`
+	Image          *string   `json:"image"`
+	Framework      *string   `json:"framework"`
+	Description    *string   `json:"description"`
+	Environment    []string  `json:"environment"`
+	RegistrySecret *string   `json:"registrySecret"`
+	Builder        *string   `json:"builder"`
+	BuildPacks     []string  `json:"buildPacks"`
+	Processes      []Process `json:"processes"`
+	CName          *CName    `json:"cname"`
+	AppUnit        *int      `json:"appUnit"`
 }
 
 type Process struct {
@@ -78,7 +78,7 @@ func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
 
 	var envs []ketchv1.Env
 	if application.Environment != nil {
-		envs, err = utils.MakeEnvironments(*application.Environment)
+		envs, err = utils.MakeEnvironments(application.Environment)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
 		var beforeHooks []string
 		var afterHooks []string
 		ketchYamlProcessConfig := make(map[string]ketchv1.KetchYamlProcessConfig)
-		for _, process := range *application.Processes {
+		for _, process := range application.Processes {
 			processes = append(processes, ketchv1.ProcessSpec{
 				Name:  process.Name,
 				Cmd:   strings.Split(process.Cmd, " "),
@@ -140,11 +140,9 @@ func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
 		appType:              application.Type,
 		image:                application.Image,
 		description:          application.Description,
-		envs:                 application.Environment,
 		framework:            application.Framework,
 		dockerRegistrySecret: application.RegistrySecret,
 		builder:              application.Builder,
-		buildPacks:           application.BuildPacks,
 		appUnit:              application.AppUnit,
 		timeout:              &o.Timeout,
 		wait:                 &o.Wait,
@@ -154,6 +152,12 @@ func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
 	}
 	if application.CName != nil {
 		c.cname = &ketchv1.CnameList{application.CName.DNSName}
+	}
+	if application.Environment != nil {
+		c.envs = &application.Environment
+	}
+	if application.BuildPacks != nil {
+		c.buildPacks = &application.BuildPacks
 	}
 	if len(processes) > 0 {
 		c.processes = &processes

--- a/internal/deploy/yaml.go
+++ b/internal/deploy/yaml.go
@@ -1,0 +1,213 @@
+package deploy
+
+import (
+	"os"
+	"strings"
+
+	"github.com/shipa-corp/ketch/internal/errors"
+	"sigs.k8s.io/yaml"
+
+	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
+)
+
+// Application represents the fields in an application.yaml file that will be
+// transitioned to a ChangeSet.
+type Application struct {
+	Version        *string    `json:"version"`
+	Type           *string    `json:"type"`
+	Name           *string    `json:"name"`
+	Image          *string    `json:"image"`
+	Framework      *string    `json:"framework"`
+	Description    *string    `json:"description"`
+	Environment    *[]string  `json:"environment"`
+	RegistrySecret *string    `json:"registrySecret"`
+	Builder        *string    `json:"builder"`
+	BuildPacks     *[]string  `json:"buildPacks"`
+	Processes      *[]Process `json:"processes"`
+	CName          *CName     `json:"cname"`
+	AppUnit        *int       `json:"appUnit"`
+}
+
+type Process struct {
+	Name  string `json:"name"`  // required
+	Cmd   string `json:"cmd"`   // required
+	Units *int   `json:"units"` // unset? get from AppUnit
+	Ports []Port `json:"ports"` // appDeploymentSpec
+	Hooks Hooks  `json:"hooks"`
+}
+
+type Port struct {
+	Protocol   string `json:"protocol"`
+	Port       int    `json:"port"`
+	TargetPort int    `json:"targetPort"`
+}
+
+type Hooks struct {
+	Restart Restart `json:"restart"`
+}
+
+type Restart struct {
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+type CName struct {
+	DNSName string `json:"dnsName"`
+}
+
+var (
+	defaultVersion  = "v1"
+	defaultAppUnit  = 1
+	typeApplication = "Application"
+	typeJob         = "Job"
+
+	errEnvvarFormat = errors.New("environment variables should be in the format - name=value")
+)
+
+// GetChangeSetFromYaml reads an application.yaml file and returns a ChangeSet
+// from the file's values.
+func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
+	var application Application
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(b, &application)
+	if err != nil {
+		return nil, err
+	}
+
+	var envs []ketchv1.Env
+	if application.Environment != nil {
+		for _, env := range *application.Environment {
+			arr := strings.Split(env, "=")
+			if len(arr) != 2 {
+				return nil, errEnvvarFormat
+			}
+			envs = append(envs, ketchv1.Env{Name: arr[0], Value: arr[1]})
+		}
+	}
+	// processes, hooks, ports
+	var processes []ketchv1.ProcessSpec
+	var ketchYamlData ketchv1.KetchYamlData
+	if application.Processes != nil {
+		var beforeHooks []string
+		var afterHooks []string
+		ketchYamlProcessConfig := make(map[string]ketchv1.KetchYamlProcessConfig)
+		for _, process := range *application.Processes {
+			processes = append(processes, ketchv1.ProcessSpec{
+				Name:  process.Name,
+				Cmd:   strings.Split(process.Cmd, " "),
+				Units: process.Units,
+				Env:   envs,
+			})
+			if process.Hooks.Restart.Before != "" {
+				beforeHooks = append(beforeHooks, process.Hooks.Restart.Before)
+			}
+			if process.Hooks.Restart.After != "" {
+				afterHooks = append(afterHooks, process.Hooks.Restart.After)
+			}
+
+			var ports []ketchv1.KetchYamlProcessPortConfig
+			for _, port := range process.Ports {
+				ports = append(ports, ketchv1.KetchYamlProcessPortConfig{
+					Protocol:   port.Protocol,
+					Port:       port.Port,
+					TargetPort: port.TargetPort,
+				})
+			}
+			if len(process.Ports) > 0 {
+				ketchYamlProcessConfig[process.Name] = ketchv1.KetchYamlProcessConfig{
+					Ports: ports,
+				}
+			}
+		}
+
+		// assign hooks and ports (kubernetes processConfig) to ketch yaml data
+		// NOTE: there is a disparity in that the yaml file format implies that hooks and ports
+		// are per-process, while the AppSpec makes them per-deployment.
+		ketchYamlData = ketchv1.KetchYamlData{
+			Hooks: &ketchv1.KetchYamlHooks{
+				Restart: ketchv1.KetchYamlRestartHooks{
+					Before: beforeHooks,
+					After:  afterHooks,
+				},
+			},
+			Kubernetes: &ketchv1.KetchYamlKubernetesConfig{
+				Processes: ketchYamlProcessConfig,
+			},
+		}
+	}
+	c := &ChangeSet{
+		appName:              *application.Name,
+		appVersion:           application.Version,
+		appType:              application.Type,
+		image:                application.Image,
+		description:          application.Description,
+		envs:                 application.Environment,
+		framework:            application.Framework,
+		dockerRegistrySecret: application.RegistrySecret,
+		builder:              application.Builder,
+		buildPacks:           application.BuildPacks,
+		appUnit:              application.AppUnit,
+		timeout:              &o.Timeout,
+		wait:                 &o.Wait,
+	}
+	if application.CName != nil {
+		c.cname = &ketchv1.CnameList{application.CName.DNSName}
+	}
+	if len(processes) > 0 {
+		c.processes = &processes
+		c.ketchYamlData = &ketchYamlData
+	}
+	c.applyDefaults()
+	return c, c.validate()
+}
+
+// apply defaults sets default values for a ChangeSet
+func (c *ChangeSet) applyDefaults() {
+	if c.appVersion == nil {
+		c.appVersion = &defaultVersion
+	}
+	if c.appType == nil {
+		c.appType = &typeApplication
+	}
+	c.yamlStrictDecoding = true
+	// building from source in PWD
+	if c.builder != nil && c.sourcePath == nil {
+		sourcePath := "."
+		c.sourcePath = &sourcePath
+	}
+	// default to AppUnits if process.Units is unset
+	if c.appUnit == nil {
+		c.appUnit = &defaultAppUnit
+	}
+	if c.processes != nil {
+		for i := range *c.processes {
+			if (*c.processes)[i].Units == nil {
+				if c.appUnit != nil {
+					(*c.processes)[i].Units = c.appUnit
+				} else {
+					(*c.processes)[i].Units = &defaultAppUnit
+				}
+			}
+		}
+	}
+}
+
+// validate assures that a ChangeSet's required fields are set
+func (c *ChangeSet) validate() error {
+	if c.framework == nil {
+		return errors.New("missing required field framework")
+	}
+	if c.image == nil {
+		return errors.New("missing required field image")
+	}
+	if c.appName == "" {
+		return errors.New("missing required field name")
+	}
+	if c.sourcePath == nil && c.processes != nil {
+		return errors.New("running defined processes require a sourcePath")
+	}
+	return nil
+}

--- a/internal/deploy/yaml.go
+++ b/internal/deploy/yaml.go
@@ -9,6 +9,7 @@ import (
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/utils"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 // Application represents the fields in an application.yaml file that will be
@@ -56,7 +57,7 @@ type CName struct {
 	DNSName string `json:"dnsName"`
 }
 
-var (
+const (
 	defaultVersion  = "v1"
 	defaultAppUnit  = 1
 	typeApplication = "Application"
@@ -170,16 +171,16 @@ func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
 // apply defaults sets default values for a ChangeSet
 func (c *ChangeSet) applyDefaults() {
 	if c.appVersion == nil {
-		c.appVersion = &defaultVersion
+		c.appVersion = conversions.StrPtr(defaultVersion)
 	}
 	if c.appType == nil {
-		c.appType = &typeApplication
+		c.appType = conversions.StrPtr(typeApplication)
 	}
 	c.yamlStrictDecoding = true
 
 	// default to AppUnits if process.Units is unset
 	if c.appUnit == nil {
-		c.appUnit = &defaultAppUnit
+		c.appUnit = conversions.IntPtr(defaultAppUnit)
 	}
 	if c.processes != nil {
 		for i := range *c.processes {

--- a/internal/deploy/yaml_test.go
+++ b/internal/deploy/yaml_test.go
@@ -56,8 +56,9 @@ appUnit: 2
 cname:
   dnsName: test.10.10.10.20`,
 			options: &Options{
-				Timeout: "1m",
-				Wait:    true,
+				Timeout:       "1m",
+				Wait:          true,
+				AppSourcePath: ".",
 			},
 			changeSet: &ChangeSet{
 				appName:              "test",
@@ -192,7 +193,9 @@ processes:
     units: 1
   - name: worker
     cmd: python app.py`,
-			options: &Options{},
+			options: &Options{
+				AppSourcePath: ".",
+			},
 			changeSet: &ChangeSet{
 				appName:            "test",
 				appUnit:            testutils.IntPtr(2),
@@ -254,7 +257,7 @@ environment:
   - bad:variable
 `,
 			options: &Options{},
-			errStr:  errEnvvarFormat.Error(),
+			errStr:  "env variables should have NAME=VALUE format",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/deploy/yaml_test.go
+++ b/internal/deploy/yaml_test.go
@@ -1,0 +1,278 @@
+package deploy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/shipa-corp/ketch/internal/testutils"
+
+	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetChangeSetFromYaml(t *testing.T) {
+	tests := []struct {
+		description string
+		yaml        string
+		options     *Options
+		changeSet   *ChangeSet
+		errStr      string
+	}{
+		{
+			description: "success",
+			yaml: `version: v1
+type: Application
+name: test
+image: gcr.io/kubernetes/sample-app:latest
+framework: myframework
+description: a test
+builder: heroku/buildpacks:20
+buildPacks: 
+  - test-buildpack
+environment:
+  - PORT=6666
+  - FOO=bar
+processes:
+  - name: web
+    cmd: python app.py
+    units: 1
+    ports:
+      - port: 8888
+        targetPort: 6666
+        protocol: TCP
+    hooks:
+      restart:
+        before: pwd
+        after: echo "test"
+  - name: worker
+    cmd: python app.py
+    units: 1
+    ports:
+      - targetPort: 6666
+        port: 8888
+        protocol: TCP
+appUnit: 2
+cname:
+  dnsName: test.10.10.10.20`,
+			options: &Options{
+				Timeout: "1m",
+				Wait:    true,
+			},
+			changeSet: &ChangeSet{
+				appName:              "test",
+				appUnit:              testutils.IntPtr(2),
+				yamlStrictDecoding:   true,
+				sourcePath:           testutils.StrPtr("."),
+				image:                testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				description:          testutils.StrPtr("a test"),
+				envs:                 &[]string{"PORT=6666", "FOO=bar"},
+				framework:            testutils.StrPtr("myframework"),
+				dockerRegistrySecret: nil,
+				builder:              testutils.StrPtr("heroku/buildpacks:20"),
+				buildPacks:           &[]string{"test-buildpack"},
+				cname:                &ketchv1.CnameList{"test.10.10.10.20"},
+				timeout:              testutils.StrPtr("1m"),
+				wait:                 testutils.BoolPtr(true),
+				processes: &[]ketchv1.ProcessSpec{
+					{
+						Name:  "web",
+						Cmd:   []string{"python", "app.py"},
+						Units: testutils.IntPtr(1),
+						Env: []ketchv1.Env{
+							{
+								Name:  "PORT",
+								Value: "6666",
+							},
+							{
+								Name:  "FOO",
+								Value: "bar",
+							},
+						},
+					},
+					{
+						Name:  "worker",
+						Cmd:   []string{"python", "app.py"},
+						Units: testutils.IntPtr(1),
+						Env: []ketchv1.Env{
+							{
+								Name:  "PORT",
+								Value: "6666",
+							},
+							{
+								Name:  "FOO",
+								Value: "bar",
+							},
+						},
+					},
+				},
+				ketchYamlData: &ketchv1.KetchYamlData{
+					Kubernetes: &ketchv1.KetchYamlKubernetesConfig{
+						Processes: map[string]ketchv1.KetchYamlProcessConfig{
+							"web": ketchv1.KetchYamlProcessConfig{
+								Ports: []ketchv1.KetchYamlProcessPortConfig{
+									{
+										Protocol:   "TCP",
+										Port:       8888,
+										TargetPort: 6666,
+									},
+								},
+							},
+							"worker": ketchv1.KetchYamlProcessConfig{
+								Ports: []ketchv1.KetchYamlProcessPortConfig{
+									{
+										Protocol:   "TCP",
+										Port:       8888,
+										TargetPort: 6666,
+									},
+								},
+							},
+						},
+					},
+					Hooks: &ketchv1.KetchYamlHooks{
+						Restart: ketchv1.KetchYamlRestartHooks{
+							Before: []string{"pwd"},
+							After:  []string{"echo \"test\""},
+						},
+					},
+				},
+				appVersion: testutils.StrPtr("v1"),
+				appType:    testutils.StrPtr("Application"),
+			},
+		},
+		{
+			description: "success - defaults",
+			yaml: `name: test
+framework: myframework
+image: gcr.io/kubernetes/sample-app:latest`,
+			options: &Options{},
+			changeSet: &ChangeSet{
+				appName:            "test",
+				appUnit:            testutils.IntPtr(1),
+				yamlStrictDecoding: true,
+				image:              testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				framework:          testutils.StrPtr("myframework"),
+				appVersion:         testutils.StrPtr("v1"),
+				appType:            testutils.StrPtr("Application"),
+				timeout:            testutils.StrPtr(""),
+				wait:               testutils.BoolPtr(false),
+			},
+		},
+		{
+			description: "validation error - framework",
+			yaml: `name: test
+image: gcr.io/kubernetes/sample-app:latest`,
+			options: &Options{},
+			errStr:  "missing required field framework",
+		},
+		{
+			description: "validation error - processes without sourcePath",
+			yaml: `name: test
+framework: myframework
+image: gcr.io/kubernetes/sample-app:latest
+processes:
+  - name: web
+    cmd: python app.py`,
+			options: &Options{},
+			errStr:  "running defined processes require a sourcePath",
+		},
+		{
+			description: "success - use appUnits as process.units when units are not specified",
+			yaml: `version: v1
+type: Application
+name: test
+image: gcr.io/kubernetes/sample-app:latest
+framework: myframework
+description: a test
+builder: heroku/buildpacks:20
+appUnit: 2
+processes:
+  - name: web
+    cmd: python app.py
+    units: 1
+  - name: worker
+    cmd: python app.py`,
+			options: &Options{},
+			changeSet: &ChangeSet{
+				appName:            "test",
+				appUnit:            testutils.IntPtr(2),
+				yamlStrictDecoding: true,
+				sourcePath:         testutils.StrPtr("."),
+				image:              testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				description:        testutils.StrPtr("a test"),
+				builder:            testutils.StrPtr("heroku/buildpacks:20"),
+				framework:          testutils.StrPtr("myframework"),
+				timeout:            testutils.StrPtr(""),
+				wait:               testutils.BoolPtr(false),
+				processes: &[]ketchv1.ProcessSpec{
+					{
+						Name:  "web",
+						Cmd:   []string{"python", "app.py"},
+						Units: testutils.IntPtr(1),
+					},
+					{
+						Name:  "worker",
+						Cmd:   []string{"python", "app.py"},
+						Units: testutils.IntPtr(2),
+					},
+				},
+				appVersion: testutils.StrPtr("v1"),
+				appType:    testutils.StrPtr("Application"),
+				ketchYamlData: &ketchv1.KetchYamlData{
+					Hooks: &ketchv1.KetchYamlHooks{
+						Restart: ketchv1.KetchYamlRestartHooks{},
+					},
+					Kubernetes: &ketchv1.KetchYamlKubernetesConfig{Processes: map[string]ketchv1.KetchYamlProcessConfig{}},
+				},
+			},
+		},
+		{
+			description: "success - no cname",
+			yaml: `name: test
+framework: myframework
+image: gcr.io/kubernetes/sample-app:latest
+`,
+			options: &Options{},
+			changeSet: &ChangeSet{
+				appName:            "test",
+				appUnit:            testutils.IntPtr(1),
+				yamlStrictDecoding: true,
+				image:              testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				framework:          testutils.StrPtr("myframework"),
+				appVersion:         testutils.StrPtr("v1"),
+				appType:            testutils.StrPtr("Application"),
+				timeout:            testutils.StrPtr(""),
+				wait:               testutils.BoolPtr(false),
+			},
+		},
+		{
+			description: "error - malformed envvar",
+			yaml: `name: test
+framework: myframework
+image: gcr.io/kubernetes/sample-app:latest
+environment:
+  - bad:variable
+`,
+			options: &Options{},
+			errStr:  errEnvvarFormat.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			file, err := os.CreateTemp(t.TempDir(), "*.yaml")
+			require.Nil(t, err)
+			_, err = file.Write([]byte(tt.yaml))
+			require.Nil(t, err)
+			defer os.Remove(file.Name())
+
+			cs, err := tt.options.GetChangeSetFromYaml(file.Name())
+			if tt.errStr != "" {
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tt.errStr)
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, tt.changeSet, cs)
+			}
+		})
+	}
+}

--- a/internal/deploy/yaml_test.go
+++ b/internal/deploy/yaml_test.go
@@ -4,11 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/shipa-corp/ketch/internal/testutils"
+	"github.com/stretchr/testify/require"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
-
-	"github.com/stretchr/testify/require"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
 func TestGetChangeSetFromYaml(t *testing.T) {
@@ -62,24 +61,24 @@ cname:
 			},
 			changeSet: &ChangeSet{
 				appName:              "test",
-				appUnit:              testutils.IntPtr(2),
+				appUnit:              conversions.IntPtr(2),
 				yamlStrictDecoding:   true,
-				sourcePath:           testutils.StrPtr("."),
-				image:                testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
-				description:          testutils.StrPtr("a test"),
+				sourcePath:           conversions.StrPtr("."),
+				image:                conversions.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				description:          conversions.StrPtr("a test"),
 				envs:                 &[]string{"PORT=6666", "FOO=bar"},
-				framework:            testutils.StrPtr("myframework"),
+				framework:            conversions.StrPtr("myframework"),
 				dockerRegistrySecret: nil,
-				builder:              testutils.StrPtr("heroku/buildpacks:20"),
+				builder:              conversions.StrPtr("heroku/buildpacks:20"),
 				buildPacks:           &[]string{"test-buildpack"},
 				cname:                &ketchv1.CnameList{"test.10.10.10.20"},
-				timeout:              testutils.StrPtr("1m"),
-				wait:                 testutils.BoolPtr(true),
+				timeout:              conversions.StrPtr("1m"),
+				wait:                 conversions.BoolPtr(true),
 				processes: &[]ketchv1.ProcessSpec{
 					{
 						Name:  "web",
 						Cmd:   []string{"python", "app.py"},
-						Units: testutils.IntPtr(1),
+						Units: conversions.IntPtr(1),
 						Env: []ketchv1.Env{
 							{
 								Name:  "PORT",
@@ -94,7 +93,7 @@ cname:
 					{
 						Name:  "worker",
 						Cmd:   []string{"python", "app.py"},
-						Units: testutils.IntPtr(1),
+						Units: conversions.IntPtr(1),
 						Env: []ketchv1.Env{
 							{
 								Name:  "PORT",
@@ -137,8 +136,8 @@ cname:
 						},
 					},
 				},
-				appVersion: testutils.StrPtr("v1"),
-				appType:    testutils.StrPtr("Application"),
+				appVersion: conversions.StrPtr("v1"),
+				appType:    conversions.StrPtr("Application"),
 			},
 		},
 		{
@@ -149,14 +148,14 @@ image: gcr.io/kubernetes/sample-app:latest`,
 			options: &Options{},
 			changeSet: &ChangeSet{
 				appName:            "test",
-				appUnit:            testutils.IntPtr(1),
+				appUnit:            conversions.IntPtr(1),
 				yamlStrictDecoding: true,
-				image:              testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
-				framework:          testutils.StrPtr("myframework"),
-				appVersion:         testutils.StrPtr("v1"),
-				appType:            testutils.StrPtr("Application"),
-				timeout:            testutils.StrPtr(""),
-				wait:               testutils.BoolPtr(false),
+				image:              conversions.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				framework:          conversions.StrPtr("myframework"),
+				appVersion:         conversions.StrPtr("v1"),
+				appType:            conversions.StrPtr("Application"),
+				timeout:            conversions.StrPtr(""),
+				wait:               conversions.BoolPtr(false),
 			},
 		},
 		{
@@ -198,29 +197,29 @@ processes:
 			},
 			changeSet: &ChangeSet{
 				appName:            "test",
-				appUnit:            testutils.IntPtr(2),
+				appUnit:            conversions.IntPtr(2),
 				yamlStrictDecoding: true,
-				sourcePath:         testutils.StrPtr("."),
-				image:              testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
-				description:        testutils.StrPtr("a test"),
-				builder:            testutils.StrPtr("heroku/buildpacks:20"),
-				framework:          testutils.StrPtr("myframework"),
-				timeout:            testutils.StrPtr(""),
-				wait:               testutils.BoolPtr(false),
+				sourcePath:         conversions.StrPtr("."),
+				image:              conversions.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				description:        conversions.StrPtr("a test"),
+				builder:            conversions.StrPtr("heroku/buildpacks:20"),
+				framework:          conversions.StrPtr("myframework"),
+				timeout:            conversions.StrPtr(""),
+				wait:               conversions.BoolPtr(false),
 				processes: &[]ketchv1.ProcessSpec{
 					{
 						Name:  "web",
 						Cmd:   []string{"python", "app.py"},
-						Units: testutils.IntPtr(1),
+						Units: conversions.IntPtr(1),
 					},
 					{
 						Name:  "worker",
 						Cmd:   []string{"python", "app.py"},
-						Units: testutils.IntPtr(2),
+						Units: conversions.IntPtr(2),
 					},
 				},
-				appVersion: testutils.StrPtr("v1"),
-				appType:    testutils.StrPtr("Application"),
+				appVersion: conversions.StrPtr("v1"),
+				appType:    conversions.StrPtr("Application"),
 				ketchYamlData: &ketchv1.KetchYamlData{
 					Hooks: &ketchv1.KetchYamlHooks{
 						Restart: ketchv1.KetchYamlRestartHooks{},
@@ -238,14 +237,14 @@ image: gcr.io/kubernetes/sample-app:latest
 			options: &Options{},
 			changeSet: &ChangeSet{
 				appName:            "test",
-				appUnit:            testutils.IntPtr(1),
+				appUnit:            conversions.IntPtr(1),
 				yamlStrictDecoding: true,
-				image:              testutils.StrPtr("gcr.io/kubernetes/sample-app:latest"),
-				framework:          testutils.StrPtr("myframework"),
-				appVersion:         testutils.StrPtr("v1"),
-				appType:            testutils.StrPtr("Application"),
-				timeout:            testutils.StrPtr(""),
-				wait:               testutils.BoolPtr(false),
+				image:              conversions.StrPtr("gcr.io/kubernetes/sample-app:latest"),
+				framework:          conversions.StrPtr("myframework"),
+				appVersion:         conversions.StrPtr("v1"),
+				appType:            conversions.StrPtr("Application"),
+				timeout:            conversions.StrPtr(""),
+				wait:               conversions.BoolPtr(false),
 			},
 		},
 		{

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -3,3 +3,11 @@ package testutils
 func IntPtr(i int) *int {
 	return &i
 }
+
+func StrPtr(s string) *string {
+	return &s
+}
+
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/utils/conversions/conversions.go
+++ b/internal/utils/conversions/conversions.go
@@ -1,4 +1,4 @@
-package testutils
+package conversions
 
 func IntPtr(i int) *int {
 	return &i


### PR DESCRIPTION
# Description

Adds basic handling of app.yaml files to deploy apps, e.g. `ketch app deploy app.yaml`. Note, the added integration test is a little crude. There is an open ticket to improve timeout/retries in integration tests. 

Fixes # SHIPA-1543

Spec: https://docs.google.com/document/d/1fMaLn7ViztU4L8nxV1sTFwLW3-64mWraOiOAE5MnlOw

_Example yaml (assumes you have ketch, traefik installed on a cluster and a framework called "myframework"):_
**app.yaml**
```
name: test
image: gcr.io/shipa-ci/sample-go-app:latest
framework: myframework
```
`ketch app deploy app.yaml`

The `--wait` and `--timeout` flags are functional when using a yaml. E.g. force a timeout `ketch app deploy app.yaml --wait --timeout 1s`. Or simply wait for app to become EventTypeNormal ketch app deploy app.yaml --wait `


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
