### PR TITLE
Jds/app yaml export

### DIFF
--- a/cli_tests/app.sh
+++ b/cli_tests/app.sh
@@ -170,6 +170,16 @@ EOF
   [[ $result =~ $dataRegex ]]
 }
 
+@test "app export" {
+  run $KETCH app export "$APP_NAME"
+  result=$(cat app.yaml)
+  echo "RECEIVED:" $result
+  [[ $result =~ "name: $APP_NAME" ]]
+  [[ $result =~ "type: Application" ]]
+  [[ $result =~ "framework: $FRAMEWORK" ]]
+  rm -f framework.yaml
+}
+
 @test "app stop" {
   result=$($KETCH app stop "$APP_NAME")
   echo "RECEIVED:" $result

--- a/cmd/ketch/app.go
+++ b/cmd/ketch/app.go
@@ -40,7 +40,7 @@ func newAppCmd(cfg config, out io.Writer, packSvc *pack.Client, configDefaultBui
 	cmd.AddCommand(newAppInfoCmd(cfg, out))
 	cmd.AddCommand(newAppStartCmd(cfg, out, appStart))
 	cmd.AddCommand(newAppStopCmd(cfg, out, appStop))
-	cmd.AddCommand(newAppExportCmd(cfg, out, appExport))
+	cmd.AddCommand(newAppExportCmd(cfg, exportApp))
 	return cmd
 }
 

--- a/cmd/ketch/app_export_test.go
+++ b/cmd/ketch/app_export_test.go
@@ -28,7 +28,7 @@ func Test_newAppExportCmd(t *testing.T) {
 	}{
 		{
 			name: "happy path",
-			args: []string{"ketch", "foo-bar"},
+			args: []string{"foo-bar"},
 			appExport: func(ctx context.Context, cfg config, options appExportOptions) error {
 				require.Equal(t, "foo-bar", options.appName)
 				return nil
@@ -36,14 +36,14 @@ func Test_newAppExportCmd(t *testing.T) {
 		},
 		{
 			name:    "missing arg",
-			args:    []string{"ketch"},
+			args:    []string{},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Args = tt.args
 			cmd := newAppExportCmd(nil, tt.appExport)
+			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
 			if tt.wantErr {
 				require.NotNil(t, err)

--- a/cmd/ketch/app_export_test.go
+++ b/cmd/ketch/app_export_test.go
@@ -1,22 +1,19 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
-	"time"
 
-	"bou.ke/monkey"
+	"github.com/shipa-corp/ketch/internal/utils/conversions"
+
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
-	"github.com/shipa-corp/ketch/internal/chart"
 	"github.com/shipa-corp/ketch/internal/mocks"
 	"github.com/shipa-corp/ketch/internal/templates"
 )
@@ -31,23 +28,22 @@ func Test_newAppExportCmd(t *testing.T) {
 	}{
 		{
 			name: "happy path",
-			args: []string{"ketch", "foo-bar", "-d", "/tmp/app"},
-			appExport: func(ctx context.Context, cfg config, chartNew chartNewFn, options appExportOptions, out io.Writer) error {
+			args: []string{"ketch", "foo-bar"},
+			appExport: func(ctx context.Context, cfg config, options appExportOptions) error {
 				require.Equal(t, "foo-bar", options.appName)
-				require.Equal(t, "/tmp/app", options.directory)
 				return nil
 			},
 		},
 		{
-			name:    "missing directory arg",
-			args:    []string{"ketch", "foo-bar"},
+			name:    "missing arg",
+			args:    []string{"ketch"},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Args = tt.args
-			cmd := newAppExportCmd(nil, nil, tt.appExport)
+			cmd := newAppExportCmd(nil, tt.appExport)
 			err := cmd.Execute()
 			if tt.wantErr {
 				require.NotNil(t, err)
@@ -73,9 +69,6 @@ func (m mockStorage) Update(name string, templates templates.Templates) error {
 var _ templates.Client = &mockStorage{}
 
 func Test_appExport(t *testing.T) {
-	directory1, err := ioutil.TempDir("", "ketch-app-export")
-	require.Nil(t, err)
-
 	dashboard := &ketchv1.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dashboard",
@@ -85,6 +78,7 @@ func Test_appExport(t *testing.T) {
 			Ingress: ketchv1.IngressSpec{
 				GenerateDefaultCname: true,
 			},
+			Version: conversions.StrPtr("v1"),
 		},
 	}
 
@@ -101,12 +95,11 @@ func Test_appExport(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		cfg      config
-		options  appExportOptions
-		chartNew chartNewFn
-		wantOut  string
-		wantErr  string
+		name    string
+		cfg     config
+		options appExportOptions
+		wantOut string
+		wantErr string
 	}{
 		{
 			name: "happy path",
@@ -120,26 +113,13 @@ func Test_appExport(t *testing.T) {
 				},
 			},
 			options: appExportOptions{
-				appName:   "dashboard",
-				directory: directory1,
+				appName: "dashboard",
 			},
-			chartNew: func(application *ketchv1.App, framework *ketchv1.Framework, opts ...chart.Option) (*chart.ApplicationChart, error) {
-				require.Equal(t, "dashboard", application.Name)
-				require.Equal(t, "gke", framework.Name)
-				return &chart.ApplicationChart{}, nil
-			},
-			wantOut: "Successfully exported!\n",
-		},
-		{
-			name: "no framework",
-			cfg: &mocks.Configuration{
-				CtrlClientObjects: []runtime.Object{dashboard},
-			},
-			options: appExportOptions{
-				appName:   "dashboard",
-				directory: directory1,
-			},
-			wantErr: `failed to get framework: frameworks.theketch.io "gke" not found`,
+			wantOut: `framework: gke
+name: dashboard
+type: Application
+version: v1
+`,
 		},
 		{
 			name: "no app",
@@ -147,39 +127,25 @@ func Test_appExport(t *testing.T) {
 				CtrlClientObjects: []runtime.Object{},
 			},
 			options: appExportOptions{
-				appName:   "dashboard",
-				directory: directory1,
+				appName: "dashboard",
 			},
 			wantErr: `failed to get app: apps.theketch.io "dashboard" not found`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// safely patch time.Now for tests
-			patch := monkey.Patch(time.Now, func() time.Time { return time.Date(2020, 12, 11, 20, 34, 58, 651387237, time.UTC) })
-			defer patch.Unpatch()
-			out := &bytes.Buffer{}
-			err := appExport(context.Background(), tt.cfg, tt.chartNew, tt.options, out)
-			if len(tt.wantErr) > 0 {
-				require.NotNil(t, err, "appExport() error = %v, wantErr %v", err, tt.wantErr)
-				require.Equal(t, tt.wantErr, err.Error())
-				return
-			}
-			require.Nil(t, err)
-			require.Equal(t, tt.wantOut, out.String())
-			files, err := ioutil.ReadDir(tt.options.directory + "/" + tt.options.appName + "_11_Dec_20_20_34_UTC")
-			require.Nil(t, err)
+			tt.options.filename = filepath.Join(t.TempDir(), "app.yaml")
+			defer os.Remove(tt.options.filename)
 
-			directoryContent := make(map[string]struct{})
-			for _, f := range files {
-				directoryContent[f.Name()] = struct{}{}
+			err := exportApp(context.Background(), tt.cfg, tt.options)
+			if tt.wantErr != "" {
+				require.Equal(t, err.Error(), tt.wantErr)
+			} else {
+				require.Nil(t, err)
+				b, err := os.ReadFile(tt.options.filename)
+				require.Nil(t, err)
+				require.Equal(t, tt.wantOut, string(b))
 			}
-			expected := map[string]struct{}{
-				"Chart.yaml":  {},
-				"templates":   {},
-				"values.yaml": {},
-			}
-			require.Equal(t, expected, directoryContent)
 		})
 	}
 }


### PR DESCRIPTION
# Description

SHIPA-1545 - adds `ketch app export <appname>` as an app.yaml file (rather than chart). Borrows most of the CLI UX from `framework export` for consistency. To determine processes, I used the latest deployment. This seems correct, but I'm not 100%.

Fixes # 1545

Quickstart:
- checkout the branch and `make ketch`
- assure you have a framework and app created, e.g.
  - `./bin/ketch framework add myframework --ingress-service-endpoint "$(k get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" --ingress-type traefik`
  - `./bin/ketch app deploy bulletinboard --framework myframework -i docker.io/shipasoftware/bulletinboard:1.0`
- `./bin/ketch app bulletinboard export`
- `cat app.yaml`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
