### PR TITLE
Export defaults to stdout + cleanup

### DIFF
--- a/cli_tests/app.sh
+++ b/cli_tests/app.sh
@@ -77,7 +77,7 @@ EOF
 }
 
 @test "framework export" {
-  run $KETCH framework export "$FRAMEWORK"
+  run $KETCH framework export "$FRAMEWORK" -f framework.yaml
   result=$(cat framework.yaml)
   echo "RECEIVED:" $result
   [[ $result =~ "name: $FRAMEWORK" ]]
@@ -171,13 +171,13 @@ EOF
 }
 
 @test "app export" {
-  run $KETCH app export "$APP_NAME"
+  run $KETCH app export "$APP_NAME" -f app.yaml
   result=$(cat app.yaml)
   echo "RECEIVED:" $result
   [[ $result =~ "name: $APP_NAME" ]]
   [[ $result =~ "type: Application" ]]
   [[ $result =~ "framework: $FRAMEWORK" ]]
-  rm -f framework.yaml
+  rm -f app.yaml
 }
 
 @test "app stop" {

--- a/cmd/ketch/app.go
+++ b/cmd/ketch/app.go
@@ -40,7 +40,7 @@ func newAppCmd(cfg config, out io.Writer, packSvc *pack.Client, configDefaultBui
 	cmd.AddCommand(newAppInfoCmd(cfg, out))
 	cmd.AddCommand(newAppStartCmd(cfg, out, appStart))
 	cmd.AddCommand(newAppStopCmd(cfg, out, appStop))
-	cmd.AddCommand(newAppExportCmd(cfg, exportApp))
+	cmd.AddCommand(newAppExportCmd(cfg, exportApp, out))
 	return cmd
 }
 

--- a/cmd/ketch/framework.go
+++ b/cmd/ketch/framework.go
@@ -39,7 +39,7 @@ func newFrameworkCmd(cfg config, out io.Writer) *cobra.Command {
 	cmd.AddCommand(newFrameworkAddCmd(cfg, out, addFramework))
 	cmd.AddCommand(newFrameworkRemoveCmd(cfg, out))
 	cmd.AddCommand(newFrameworkUpdateCmd(cfg, out))
-	cmd.AddCommand(newFrameworkExportCmd(cfg))
+	cmd.AddCommand(newFrameworkExportCmd(cfg, out))
 	return cmd
 }
 

--- a/cmd/ketch/framework_add.go
+++ b/cmd/ketch/framework_add.go
@@ -150,6 +150,7 @@ func newFrameworkFromArgs(options frameworkAddOptions) *ketchv1.Framework {
 			Name: options.name,
 		},
 		Spec: ketchv1.FrameworkSpec{
+			Name:          options.name,
 			NamespaceName: namespace,
 			AppQuotaLimit: &options.appQuotaLimit,
 			IngressController: ketchv1.IngressControllerSpec{

--- a/cmd/ketch/framework_add_test.go
+++ b/cmd/ketch/framework_add_test.go
@@ -106,6 +106,7 @@ ingressController:
 				ingressClusterIssuer:   "le-production",
 			},
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
+				Name:          "hello",
 				NamespaceName: "gke",
 				AppQuotaLimit: conversions.IntPtr(5),
 				IngressController: ketchv1.IngressControllerSpec{
@@ -135,6 +136,7 @@ ingressController:
 				ingressClusterIssuer:   "le-production",
 			},
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
+				Name:          "hello",
 				NamespaceName: "gke",
 				AppQuotaLimit: conversions.IntPtr(5),
 				IngressController: ketchv1.IngressControllerSpec{
@@ -160,6 +162,7 @@ ingressController:
 				ingressType:            traefik,
 			},
 			wantFrameworkSpec: ketchv1.FrameworkSpec{
+				Name:          "aws",
 				NamespaceName: "ketch-aws",
 				AppQuotaLimit: conversions.IntPtr(5),
 				IngressController: ketchv1.IngressControllerSpec{
@@ -367,6 +370,7 @@ func TestNewFrameworkFromArgs(t *testing.T) {
 					Name: "hello",
 				},
 				Spec: ketchv1.FrameworkSpec{
+					Name:          "hello",
 					NamespaceName: "my-namespace",
 					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{
@@ -389,6 +393,7 @@ func TestNewFrameworkFromArgs(t *testing.T) {
 					Name: "hello",
 				},
 				Spec: ketchv1.FrameworkSpec{
+					Name:          "hello",
 					NamespaceName: "ketch-hello",
 					AppQuotaLimit: conversions.IntPtr(5),
 					IngressController: ketchv1.IngressControllerSpec{

--- a/internal/deploy/yaml.go
+++ b/internal/deploy/yaml.go
@@ -16,7 +16,7 @@ import (
 // Application represents the fields in an application.yaml file that will be
 // transitioned to a ChangeSet.
 type Application struct {
-	Version        *string   `json:"version"`
+	Version        *string   `json:"version,omitempty"`
 	Type           *string   `json:"type"`
 	Name           *string   `json:"name"`
 	Image          *string   `json:"image,omitempty"`


### PR DESCRIPTION
# Description

- Adds `name` to `framework` when framework is created via cli args.
- defaults export commands to stdout, rather than yaml file
- adds omitempty on `application.version` in yaml pkg to prevent "version: null" when there is no version specified


Fixes # 1626

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
