### PR TITLE
install ketch CLI on apple m1 machines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ getPlatform() {
   case "${UNAME}" in
   Darwin)
     OSX_ARCH=$(uname -m)
-    if [ "${OSX_ARCH}" = "x86_64" ]; then
+    if [ "${OSX_ARCH}" = "x86_64" ] || [ "${OSX_ARCH}" = "arm64" ]; then
       PLATFORM="darwin-amd64"
     else
       echo "Sorry, architecture not supported: ${OSX_ARCH}. Download binary from ${RELEASE_DOWNLOAD_URL}"


### PR DESCRIPTION
This simple fix enables ketch installation on apple m1 machines. I tested, it works well as apple m1 allows running darwin-amd64 binaries via rosetta2 automatically.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (documentation addition or typo, file relocation)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
