### PR TITLE
rm hooks, cmd, ports from app.yaml processes; default to 1 unit; rm a…

### DIFF
--- a/internal/deploy/parameters.go
+++ b/internal/deploy/parameters.go
@@ -116,7 +116,6 @@ type ChangeSet struct {
 	buildPacks           *[]string
 	appVersion           *string
 	appType              *string
-	appUnit              *int
 	processes            *[]ketchv1.ProcessSpec
 	ketchYamlData        *ketchv1.KetchYamlData
 	cname                *ketchv1.CnameList
@@ -329,7 +328,7 @@ func (c *ChangeSet) getBuilder(spec ketchv1.AppSpec) string {
 
 func (c *ChangeSet) getUnits() (int, error) {
 	if c.units == nil {
-		return 0, nil
+		return 1, nil
 	}
 	if *c.units < 1 {
 		return 0, fmt.Errorf("%w %s must be 1 or greater",
@@ -410,8 +409,4 @@ func (c *ChangeSet) getKetchYaml() (*ketchv1.KetchYamlData, error) {
 		return nil, err
 	}
 	return data, nil
-}
-
-func (c *ChangeSet) getAppUnit() int {
-	return *c.appUnit
 }


### PR DESCRIPTION
Removes `process.cmd`, `process.hooks`, `process.ports`, and `appUnit` from the `Application` created when parsing app.yaml during `app deploy <file>`. Deploying an app from source via yaml (`app deploy app.yaml .`) assures that there is a Procfile in the directory, since no processes are specified in the yaml.

The decision came as a result of our office hours discussion and is noted in the issue. Defaults `units` to 1 and fixes an issue where `processes` were not being returned as part of `app export`. 

Fixes # 1647

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
