### PR TITLE
Default Job completions to parallelism and add acceptance test

### DIFF
--- a/cli_tests/job.sh
+++ b/cli_tests/job.sh
@@ -80,34 +80,6 @@ EOF
   [[ $result =~ "framework: $JOB_FRAMEWORK" ]]
 }
 
-@test "job completions" {
-  # completions should default to parallelism, if unset
-
-  # retry for job
-  count=0
-  until [[ $count -ge 5 ]]
-  do
-    result=$(kubectl get job -A)
-    if [[ $result =~ $JOB_NAME ]]
-      then break
-    fi
-    count+=1
-    sleep 7
-  done
-
-  result=$(kubectl get job "$JOB_NAME" -n "ketch-$JOB_FRAMEWORK")
-  completionsRegex="[0-2]/2" # completions probably won't be finished - may be 0/2 or 1/2
-  echo "RECEIVED:" $result
-  [[ $result =~ $completionsRegex ]]
-
-  result=$(kubectl describe job "$JOB_NAME" -n "ketch-$JOB_FRAMEWORK")
-  completionsRegex="Completions: *2" # variable spaces
-  parallelismRegex="Parallelism: *2" # variable spaces
-  echo "RECEIVED:" $result
-  [[ $result =~ $completionsRegex ]]
-  [[ $result =~ $parallelismRegex ]]
-}
-
 @test "job remove" {
   result=$($KETCH job remove "$JOB_NAME")
   echo "RECEIVED:" $result

--- a/cmd/ketch/job_deploy.go
+++ b/cmd/ketch/job_deploy.go
@@ -77,8 +77,8 @@ func setJobSpecDefaults(jobSpec *ketchv1.JobSpec) {
 	if jobSpec.Parallelism == 0 {
 		jobSpec.Parallelism = defaultJobParallelism
 	}
-	if jobSpec.Completions == 0 && jobSpec.Parallelism > 1 {
-		jobSpec.Completions = defaultJobCompletions
+	if jobSpec.Completions == 0 {
+		jobSpec.Completions = jobSpec.Parallelism
 	}
 	if jobSpec.BackoffLimit == 0 {
 		jobSpec.BackoffLimit = defaultJobBackoffLimit


### PR DESCRIPTION
# Description

`Job` completions value should default to the parallelism value if unset (per discussion w/ Vivek and K8s Job docs). Adds an integration test that asserts that `Job` `completions` and `parallelism` values are as expected.

Fixes # [1865](https://shipaio.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=SHIPA&modal=detail&selectedIssue=SHIPA-1865) - this is the **3rd item** listed in this issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

