### PR TITLE
Clarify error message to user when framework already exists

### DIFF
--- a/cli_tests/app.sh
+++ b/cli_tests/app.sh
@@ -41,6 +41,12 @@ teardown() {
   [[ $result =~ "Successfully added!" ]]
 }
 
+@test "framework add error" {
+  run $KETCH framework add "$FRAMEWORK" --ingress-service-endpoint "$INGRESS" --ingress-type "traefik"
+  [[ $status -eq 1 ]]
+  [[ $output =~ "\"$FRAMEWORK\" already exists" ]]
+}
+
 @test "framework add with yaml file" {
   cat << EOF > framework.yaml
 name: "$FRAMEWORK-2"

--- a/cmd/ketch/framework_add.go
+++ b/cmd/ketch/framework_add.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag"
@@ -107,6 +108,9 @@ func addFramework(ctx context.Context, cfg config, options frameworkAddOptions, 
 	}
 
 	if err := cfg.Client().Create(ctx, framework); err != nil {
+		if strings.Contains(err.Error(), ketchv1.ErrNamespaceIsUsedByAnotherFramework.Error()) {
+			return fmt.Errorf("framework \"%s\" already exists", framework.Spec.Name)
+		}
 		return fmt.Errorf("failed to create framework: %w", err)
 	}
 	fmt.Fprintln(out, "Successfully added!")


### PR DESCRIPTION
# Description

The error message to the user when trying to create a framework that already exists is unclear. This PR just checks the error and displays a clearer message. Adds test. If there's a better way to clarify errors generated by webhooks, let me know. 

This is the first item in issue below: 

Fixes # [1865](https://shipaio.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=SHIPA&modal=detail&selectedIssue=SHIPA-1865)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
