### PR TITLE
Fix framework column in "kubectl get apps.theketch.io"

### DIFF
--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -17,7 +17,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.Framework
+    - jsonPath: .spec.framework
       name: Framework
       type: string
     - jsonPath: .spec.description

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -201,7 +201,7 @@ type AppSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Framework",type=string,JSONPath=`.spec.Framework`
+// +kubebuilder:printcolumn:name="Framework",type=string,JSONPath=`.spec.framework`
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`
 
 // App is the Schema for the apps API.


### PR DESCRIPTION
This PR fixes the following:
```bash
$ k get apps.theketch.io
NAME    FRAMEWORK   DESCRIPTION
myapp               
```
It should be 
```bash
$ k get apps.theketch.io
NAME    FRAMEWORK   DESCRIPTION
myapp    <framework>             
```

Fixes # (issue)

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)