### PR TITLE
Remove ketch imports from internal/api/v1beta1 package

### DIFF
--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -23,8 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/shipa-corp/ketch/internal/templates"
 )
 
 func init() {
@@ -385,11 +383,6 @@ func (app *App) DefaultCname(framework *Framework) *string {
 	}
 	url := fmt.Sprintf("%s.%s.%s", app.Name, framework.Spec.IngressController.ServiceEndpoint, ShipaCloudDomain)
 	return &url
-}
-
-// TemplatesConfigMapName returns a name of a configmap that contains templates used to render a helm chart.
-func (app *App) TemplatesConfigMapName(ingressControllerType IngressControllerType) string {
-	return templates.IngressConfigMapName(ingressControllerType.String())
 }
 
 // Units returns a total number units.

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -490,37 +490,6 @@ func TestApp_CNames(t *testing.T) {
 	}
 }
 
-func TestApp_TemplatesConfigMapName(t *testing.T) {
-	tests := []struct {
-		name        string
-		app         App
-		ingressType IngressControllerType
-
-		want string
-	}{
-		{
-			name:        "istio configmap",
-			app:         App{},
-			ingressType: IstioIngressControllerType,
-			want:        "ingress-istio-templates",
-		},
-		{
-			name:        "traefik configmap",
-			app:         App{},
-			ingressType: TraefikIngressControllerType,
-			want:        "ingress-traefik-templates",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.app.TemplatesConfigMapName(tt.ingressType)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("TemplatesConfigMapName() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestApp_Units(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/api/v1beta1/job_types.go
+++ b/internal/api/v1beta1/job_types.go
@@ -16,8 +16,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/shipa-corp/ketch/internal/templates"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -89,11 +87,6 @@ const (
 
 func init() {
 	SchemeBuilder.Register(&Job{}, &JobList{})
-}
-
-// TemplatesConfigMapName returns a name of a configmap that contains templates used to render a helm chart.
-func (j *Job) TemplatesConfigMapName() string {
-	return templates.JobConfigMapName()
 }
 
 // Condition looks for a condition with the provided type in the condition list and returns it.

--- a/internal/controllers/app_controller.go
+++ b/internal/controllers/app_controller.go
@@ -161,7 +161,7 @@ func (r *AppReconciler) reconcile(ctx context.Context, app *ketchv1.App) reconci
 			message: fmt.Sprintf(`framework "%s" is not linked to a kubernetes namespace`, framework.Name),
 		}
 	}
-	tpls, err := r.TemplateReader.Get(app.TemplatesConfigMapName(framework.Spec.IngressController.IngressType))
+	tpls, err := r.TemplateReader.Get(templates.IngressConfigMapName(framework.Spec.IngressController.IngressType.String()))
 	if err != nil {
 		return reconcileResult{
 			status:  v1.ConditionFalse,

--- a/internal/controllers/job_controller.go
+++ b/internal/controllers/job_controller.go
@@ -120,7 +120,7 @@ func (r *JobReconciler) reconcile(ctx context.Context, job *ketchv1.Job) reconci
 			message: fmt.Sprintf(`framework "%s" is not linked to a kubernetes namespace`, framework.Name),
 		}
 	}
-	tpls, err := r.TemplateReader.Get(job.TemplatesConfigMapName())
+	tpls, err := r.TemplateReader.Get(templates.JobConfigMapName())
 	if err != nil {
 		return reconcileResult{
 			status:  v1.ConditionFalse,

--- a/internal/templates/storage_test.go
+++ b/internal/templates/storage_test.go
@@ -1,0 +1,33 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngressConfigMapName(t *testing.T) {
+	tests := []struct {
+		name        string
+		ingressType string
+
+		want string
+	}{
+		{
+			name:        "istio configmap",
+			ingressType: "istio",
+			want:        "ingress-istio-templates",
+		},
+		{
+			name:        "traefik configmap",
+			ingressType: "traefik",
+			want:        "ingress-traefik-templates",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configMapName := IngressConfigMapName(tt.ingressType)
+			require.Equal(t, tt.want, configMapName)
+		})
+	}
+}


### PR DESCRIPTION
Remove ketch imports from internal/api/v1beta1 package, so the types can be used independently without importing ketch itself

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [x] This change requires no testing (i.e. documentation update)

