### PR TITLE
Remove unused "build" section from ketch.yaml

### DIFF
--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -179,12 +179,6 @@ spec:
                           description: Hooks allow to run commands during different
                             stages of the application deployment.
                           properties:
-                            build:
-                              description: Build defines commands that are run as
-                                part of the Dockerfile build
-                              items:
-                                type: string
-                              type: array
                             restart:
                               description: Restart describes commands to run during
                                 different stages of the application deployment.

--- a/internal/api/v1beta1/ketch_yaml.go
+++ b/internal/api/v1beta1/ketch_yaml.go
@@ -16,9 +16,6 @@ type KetchYamlData struct {
 // KetchYamlHooks describes commands to run during different stages of the application deployment.
 type KetchYamlHooks struct {
 
-	// Build defines commands that are run as part of the Dockerfile build
-	Build []string `json:"build,omitempty"`
-
 	// Restart describes commands to run during different stages of the application deployment.
 	Restart KetchYamlRestartHooks `json:"restart,omitempty"`
 }


### PR DESCRIPTION
This PR removes the unused "build" section from `ketch.yaml`. After introducing buildpacks this section is not used. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] This change requires no testing (i.e. documentation update)

