### PR TITLE
Uses Group as prefix for apps' labels

### DIFF
--- a/cmd/ketch/configuration/configuration.go
+++ b/cmd/ketch/configuration/configuration.go
@@ -25,7 +25,7 @@ var (
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
-	_ = ketchv1.AddToScheme(scheme)
+	_ = ketchv1.AddToScheme()(scheme)
 }
 
 // Configuration provides methods to get initialized clients.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,22 +40,22 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
-func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = ketchv1.AddToScheme(scheme)
-	// +kubebuilder:scaffold:scheme
-}
-
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var disableWebhooks bool
+	var group string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&disableWebhooks, "disable-webhooks", false, "Disable webhooks.")
+	flag.StringVar(&group, "group", ketchv1.TheKetchGroup, "specify a non-default group")
 	flag.Parse()
+
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = ketchv1.AddToScheme(ketchv1.WithGroup(group))(scheme)
+	// +kubebuilder:scaffold:scheme
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -25,10 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func init() {
-	SchemeBuilder.Register(&App{}, &AppList{})
-}
-
 const (
 	ShipaCloudDomain     = "shipa.cloud"
 	DefaultNumberOfUnits = 1

--- a/internal/api/v1beta1/framework_types.go
+++ b/internal/api/v1beta1/framework_types.go
@@ -21,10 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func init() {
-	SchemeBuilder.Register(&Framework{}, &FrameworkList{})
-}
-
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status

--- a/internal/api/v1beta1/job_types.go
+++ b/internal/api/v1beta1/job_types.go
@@ -85,10 +85,6 @@ const (
 	OnFailure RestartPolicy = "OnFailure"
 )
 
-func init() {
-	SchemeBuilder.Register(&Job{}, &JobList{})
-}
-
 // Condition looks for a condition with the provided type in the condition list and returns it.
 func (s JobStatus) Condition(t ConditionType) *Condition {
 	for _, c := range s.Conditions {

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -61,7 +61,8 @@ type app struct {
 	// IsAccessible if not set, ketch won't create kubernetes objects like Ingress/Gateway to handle incoming request.
 	// These objects could be broken without valid routes to the application.
 	// For example, "spec.rules" of an Ingress object must contain at least one rule.
-	IsAccessible bool `json:"isAccessible"`
+	IsAccessible bool   `json:"isAccessible"`
+	Group        string `json:"group"`
 }
 
 type deployment struct {
@@ -126,6 +127,7 @@ func New(application *ketchv1.App, framework *ketchv1.Framework, opts ...Option)
 			Name:    application.Name,
 			Ingress: newIngress(*application, *framework),
 			Env:     application.Spec.Env,
+			Group:   ketchv1.Group,
 		},
 		IngressController: &framework.Spec.IngressController,
 	}

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -316,7 +316,7 @@ metadata:
     theketch.io/app-name: dashboard
   name: dashboard-http-gateway
 spec:
-  selector: 
+  selector:
     istio: ingressgateway
   servers:
   - port:
@@ -350,7 +350,7 @@ spec:
     - theketch.io
     - app.theketch.io
     - dashboard.20.20.20.20.shipa.cloud
-    gateways: 
+    gateways:
     - dashboard-http-gateway
     http:
     - route:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   labels:
     app: dashboard-web-3
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: web
-    theketch.io/app-deployment-version: "3"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: web
+    shipa.io/app-deployment-version: "3"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-web-3
 spec:
   type: ClusterIP
@@ -18,10 +18,10 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: web
-    theketch.io/app-deployment-version: "3"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: web
+    shipa.io/app-deployment-version: "3"
+    shipa.io/is-isolated-run: "false"
 ---
 # Source: dashboard/templates/service.yaml
 apiVersion: v1
@@ -29,10 +29,10 @@ kind: Service
 metadata:
   labels:
     app: dashboard-worker-3
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: worker
-    theketch.io/app-deployment-version: "3"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: worker
+    shipa.io/app-deployment-version: "3"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-worker-3
 spec:
   type: ClusterIP
@@ -42,10 +42,10 @@ spec:
       protocol: TCP
       targetPort: 9090
   selector:
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: worker
-    theketch.io/app-deployment-version: "3"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: worker
+    shipa.io/app-deployment-version: "3"
+    shipa.io/is-isolated-run: "false"
 ---
 # Source: dashboard/templates/service.yaml
 apiVersion: v1
@@ -53,10 +53,10 @@ kind: Service
 metadata:
   labels:
     app: dashboard-web-4
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: web
-    theketch.io/app-deployment-version: "4"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: web
+    shipa.io/app-deployment-version: "4"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-web-4
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ spec:
       protocol: TCP
       targetPort: 9091
   selector:
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: web
-    theketch.io/app-deployment-version: "4"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: web
+    shipa.io/app-deployment-version: "4"
+    shipa.io/is-isolated-run: "false"
 ---
 # Source: dashboard/templates/service.yaml
 apiVersion: v1
@@ -77,10 +77,10 @@ kind: Service
 metadata:
   labels:
     app: dashboard-worker-4
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: worker
-    theketch.io/app-deployment-version: "4"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: worker
+    shipa.io/app-deployment-version: "4"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-worker-4
 spec:
   type: ClusterIP
@@ -90,10 +90,10 @@ spec:
       protocol: TCP
       targetPort: 9091
   selector:
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: worker
-    theketch.io/app-deployment-version: "4"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: worker
+    shipa.io/app-deployment-version: "4"
+    shipa.io/is-isolated-run: "false"
 ---
 # Source: dashboard/templates/deployment.yaml
 apiVersion: apps/v1
@@ -101,29 +101,29 @@ kind: Deployment
 metadata:
   labels:
     app: dashboard-web-3
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: web
-    theketch.io/app-process-replicas: "3"
-    theketch.io/app-deployment-version: "3"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: web
+    shipa.io/app-process-replicas: "3"
+    shipa.io/app-deployment-version: "3"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-web-3
 spec:
   replicas: 3
   selector:
     matchLabels:
       app: dashboard-web-3
-      theketch.io/app-name: dashboard
-      theketch.io/app-process: web
-      theketch.io/app-deployment-version: "3"
-      theketch.io/is-isolated-run: "false"
+      shipa.io/app-name: dashboard
+      shipa.io/app-process: web
+      shipa.io/app-deployment-version: "3"
+      shipa.io/is-isolated-run: "false"
   template:
     metadata:
       labels:
         app: dashboard-web-3
-        theketch.io/app-name: dashboard
-        theketch.io/app-process: web
-        theketch.io/app-deployment-version: "3"
-        theketch.io/is-isolated-run: "false"
+        shipa.io/app-name: dashboard
+        shipa.io/app-process: web
+        shipa.io/app-deployment-version: "3"
+        shipa.io/is-isolated-run: "false"
     spec:
       containers:
         - name: dashboard-web-3
@@ -169,29 +169,29 @@ kind: Deployment
 metadata:
   labels:
     app: dashboard-worker-3
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: worker
-    theketch.io/app-process-replicas: "1"
-    theketch.io/app-deployment-version: "3"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: worker
+    shipa.io/app-process-replicas: "1"
+    shipa.io/app-deployment-version: "3"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-worker-3
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: dashboard-worker-3
-      theketch.io/app-name: dashboard
-      theketch.io/app-process: worker
-      theketch.io/app-deployment-version: "3"
-      theketch.io/is-isolated-run: "false"
+      shipa.io/app-name: dashboard
+      shipa.io/app-process: worker
+      shipa.io/app-deployment-version: "3"
+      shipa.io/is-isolated-run: "false"
   template:
     metadata:
       labels:
         app: dashboard-worker-3
-        theketch.io/app-name: dashboard
-        theketch.io/app-process: worker
-        theketch.io/app-deployment-version: "3"
-        theketch.io/is-isolated-run: "false"
+        shipa.io/app-name: dashboard
+        shipa.io/app-process: worker
+        shipa.io/app-deployment-version: "3"
+        shipa.io/is-isolated-run: "false"
     spec:
       containers:
         - name: dashboard-worker-3
@@ -218,29 +218,29 @@ kind: Deployment
 metadata:
   labels:
     app: dashboard-web-4
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: web
-    theketch.io/app-process-replicas: "3"
-    theketch.io/app-deployment-version: "4"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: web
+    shipa.io/app-process-replicas: "3"
+    shipa.io/app-deployment-version: "4"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-web-4
 spec:
   replicas: 3
   selector:
     matchLabels:
       app: dashboard-web-4
-      theketch.io/app-name: dashboard
-      theketch.io/app-process: web
-      theketch.io/app-deployment-version: "4"
-      theketch.io/is-isolated-run: "false"
+      shipa.io/app-name: dashboard
+      shipa.io/app-process: web
+      shipa.io/app-deployment-version: "4"
+      shipa.io/is-isolated-run: "false"
   template:
     metadata:
       labels:
         app: dashboard-web-4
-        theketch.io/app-name: dashboard
-        theketch.io/app-process: web
-        theketch.io/app-deployment-version: "4"
-        theketch.io/is-isolated-run: "false"
+        shipa.io/app-name: dashboard
+        shipa.io/app-process: web
+        shipa.io/app-deployment-version: "4"
+        shipa.io/is-isolated-run: "false"
     spec:
       containers:
         - name: dashboard-web-4
@@ -266,29 +266,29 @@ kind: Deployment
 metadata:
   labels:
     app: dashboard-worker-4
-    theketch.io/app-name: dashboard
-    theketch.io/app-process: worker
-    theketch.io/app-process-replicas: "1"
-    theketch.io/app-deployment-version: "4"
-    theketch.io/is-isolated-run: "false"
+    shipa.io/app-name: dashboard
+    shipa.io/app-process: worker
+    shipa.io/app-process-replicas: "1"
+    shipa.io/app-deployment-version: "4"
+    shipa.io/is-isolated-run: "false"
   name: dashboard-worker-4
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: dashboard-worker-4
-      theketch.io/app-name: dashboard
-      theketch.io/app-process: worker
-      theketch.io/app-deployment-version: "4"
-      theketch.io/is-isolated-run: "false"
+      shipa.io/app-name: dashboard
+      shipa.io/app-process: worker
+      shipa.io/app-deployment-version: "4"
+      shipa.io/is-isolated-run: "false"
   template:
     metadata:
       labels:
         app: dashboard-worker-4
-        theketch.io/app-name: dashboard
-        theketch.io/app-process: worker
-        theketch.io/app-deployment-version: "4"
-        theketch.io/is-isolated-run: "false"
+        shipa.io/app-name: dashboard
+        shipa.io/app-process: worker
+        shipa.io/app-deployment-version: "4"
+        shipa.io/is-isolated-run: "false"
     spec:
       containers:
         - name: dashboard-worker-4
@@ -313,7 +313,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: dashboard-cname-7698da46d42bea3603f2
-  namespace: istio-system
 spec:
   secretName: dashboard-cname-7698da46d42bea3603f2
   dnsNames:
@@ -327,7 +326,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: dashboard-cname-1aacb41a573151295624
-  namespace: istio-system
 spec:
   secretName: dashboard-cname-1aacb41a573151295624
   dnsNames:
@@ -336,91 +334,62 @@ spec:
     name: letsencrypt-production
     kind: ClusterIssuer
 ---
-# Source: dashboard/templates/gateway.yaml
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
+# Source: dashboard/templates/ingressroute.yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
 metadata:
-  labels:
-    theketch.io/app-name: dashboard
-  name: dashboard-http-gateway
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - port:
-      number: 80
-      name: http-3
-      protocol: HTTP
-    hosts:
-    - dashboard.10.10.10.10.shipa.cloud
-  - port:
-      number: 443
-      name: https-3-theketch.io
-      protocol: HTTPS
-    tls:
-      mode: SIMPLE
-      credentialName: dashboard-cname-7698da46d42bea3603f2
-    hosts:
-    - theketch.io
-  - port:
-      number: 443
-      name: https-3-app.theketch.io
-      protocol: HTTPS
-    tls:
-      mode: SIMPLE
-      credentialName: dashboard-cname-1aacb41a573151295624
-    hosts:
-    - app.theketch.io
-  - port:
-      number: 80
-      name: http-4
-      protocol: HTTP
-    hosts:
-    - dashboard.10.10.10.10.shipa.cloud
-  - port:
-      number: 443
-      name: https-4-theketch.io
-      protocol: HTTPS
-    tls:
-      mode: SIMPLE
-      credentialName: dashboard-cname-7698da46d42bea3603f2
-    hosts:
-    - theketch.io
-  - port:
-      number: 443
-      name: https-4-app.theketch.io
-      protocol: HTTPS
-    tls:
-      mode: SIMPLE
-      credentialName: dashboard-cname-1aacb41a573151295624
-    hosts:
-    - app.theketch.io
----
-# Source: dashboard/templates/virtualService.yaml
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
+  name: dashboard-http-ingressroute
   annotations:
     kubernetes.io/ingress.class: ingress-class
+    cert-manager.io/cluster-issuer: letsencrypt-production
   labels:
-    theketch.io/app-name: dashboard
-  name: dashboard-http
+    shipa.io/app-name: dashboard
 spec:
-    hosts:
-    - dashboard.10.10.10.10.shipa.cloud
-    - theketch.io
-    - app.theketch.io
-    gateways:
-    - dashboard-http-gateway
-    http:
-    - route:
-        - destination:
-            host: dashboard-web-3
-            port:
-              number: 9090
-          weight: 30
-        - destination:
-            host: dashboard-web-4
-            port:
-              number: 9091
-          weight: 70
+  entryPoints:
+    - web
+  routes:
+  - match: Host("dashboard.10.10.10.10.shipa.cloud")
+    kind: Rule
+    services:
+    - name: dashboard-web-3
+      port: 9090
+      weight: 30
+    - name: dashboard-web-4
+      port: 9091
+      weight: 70
+---
+# Source: dashboard/templates/ingressroute.yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dashboard-https-ingressroute
+  annotations:
+    kubernetes.io/ingress.class: ingress-class
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  labels:
+    shipa.io/app-name: dashboard
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: Host("theketch.io")
+    kind: Rule
+    services:
+    - name: dashboard-web-3
+      port: 9090
+      weight: 30
+    - name: dashboard-web-4
+      port: 9091
+      weight: 70
+  - match: Host("app.theketch.io")
+    kind: Rule
+    services:
+    - name: dashboard-web-3
+      port: 9090
+      weight: 30
+    - name: dashboard-web-4
+      port: 9091
+      weight: 70
+  tls:
+    secretName: dashboard-cname-7698da46d42bea3603f2
+    secretName: dashboard-cname-1aacb41a573151295624

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -389,7 +389,7 @@ spec:
       weight: 30
     - name: dashboard-web-4
       port: 9091
-      weight: 70  
-  tls: 
-    secretName: dashboard-cname-7698da46d42bea3603f2 
+      weight: 70
+  tls:
+    secretName: dashboard-cname-7698da46d42bea3603f2
     secretName: dashboard-cname-1aacb41a573151295624

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -78,7 +78,7 @@ func setup(reader templates.Reader, helm Helm, objects []client.Object) (*testin
 	if err != nil {
 		return nil, err
 	}
-	if err = ketchv1.AddToScheme(scheme.Scheme); err != nil {
+	if err = ketchv1.AddToScheme()(scheme.Scheme); err != nil {
 		return nil, err
 	}
 	ctx.k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/internal/mocks/configuration.go
+++ b/internal/mocks/configuration.go
@@ -19,7 +19,7 @@ var (
 
 func init() {
 	_ = kubeFake.AddToScheme(scheme)
-	_ = ketchv1.AddToScheme(scheme)
+	_ = ketchv1.AddToScheme()(scheme)
 }
 
 // Configuration provides a way to mock clients.

--- a/internal/templates/common/yamls/deployment.yaml
+++ b/internal/templates/common/yamls/deployment.yaml
@@ -5,11 +5,11 @@ kind: Deployment
 metadata:
   labels:
     app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
-    theketch.io/app-name: {{ $.Values.app.name }}
-    theketch.io/app-process: {{ $process.name }}
-    theketch.io/app-process-replicas: {{ $process.units | quote }}
-    theketch.io/app-deployment-version: {{ $deployment.version | quote }}
-    theketch.io/is-isolated-run: "false"
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-process: {{ $process.name }}
+    {{ $.Values.app.group }}/app-process-replicas: {{ $process.units | quote }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
+    {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $i, $label := $deployment.labels }}
     {{ $label.name }}: {{ $label.value }}
     {{- end }}
@@ -19,18 +19,18 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
-      theketch.io/app-name: {{ $.Values.app.name }}
-      theketch.io/app-process: {{ $process.name }}
-      theketch.io/app-deployment-version: {{ $deployment.version | quote }}
-      theketch.io/is-isolated-run: "false"
+      {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
+      {{ $.Values.app.group }}/app-process: {{ $process.name }}
+      {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
+      {{ $.Values.app.group }}/is-isolated-run: "false"
   template:
     metadata:
       labels:
         app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
-        theketch.io/app-name: {{ $.Values.app.name }}
-        theketch.io/app-process: {{ $process.name }}
-        theketch.io/app-deployment-version: {{ $deployment.version | quote }}
-        theketch.io/is-isolated-run: "false"
+        {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
+        {{ $.Values.app.group }}/app-process: {{ $process.name }}
+        {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
+        {{ $.Values.app.group }}/is-isolated-run: "false"
     spec:
       containers:
         - name: {{ $.Values.app.name }}-{{ $process.name }}-{{ $deployment.version }}

--- a/internal/templates/common/yamls/service.yaml
+++ b/internal/templates/common/yamls/service.yaml
@@ -6,10 +6,10 @@ kind: Service
 metadata:
   labels:
     app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
-    theketch.io/app-name: {{ $.Values.app.name }}
-    theketch.io/app-process: {{ $process.name }}
-    theketch.io/app-deployment-version: {{ $deployment.version | quote }}
-    theketch.io/is-isolated-run: "false"
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-process: {{ $process.name }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
+    {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $i, $label := $deployment.labels }}
     {{ $label.name }}: {{ $label.value }}
     {{- end }}
@@ -19,10 +19,10 @@ spec:
   ports:
 {{ $process.servicePorts | toYaml | indent 4 }}
   selector:
-    theketch.io/app-name: {{ $.Values.app.name }}
-    theketch.io/app-process: {{ $process.name }}
-    theketch.io/app-deployment-version: {{ $deployment.version | quote }}
-    theketch.io/is-isolated-run: "false"
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-process: {{ $process.name }}
+    {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
+    {{ $.Values.app.group }}/is-isolated-run: "false"
 ---
   {{- end }}
   {{ end }}

--- a/internal/templates/istio/yamls/gateway.yaml
+++ b/internal/templates/istio/yamls/gateway.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   labels:
-    theketch.io/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
   name: {{ $.Values.app.name }}-http-gateway
 spec:
-  selector: 
+  selector:
     istio: ingressgateway
   servers:
     {{- range $_, $deployment := $.Values.app.deployments }}
@@ -24,7 +24,7 @@ spec:
       {{- end }}
         {{- end }}
     {{- if  $.Values.app.ingress.https }}
-    {{- range $_, $https := $.Values.app.ingress.https }} 
+    {{- range $_, $https := $.Values.app.ingress.https }}
   - port:
       number: 443
       name: https-{{ $deployment.version }}-{{ $https.cname }}

--- a/internal/templates/istio/yamls/virtualService.yaml
+++ b/internal/templates/istio/yamls/virtualService.yaml
@@ -8,10 +8,10 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingressController.className }}
     {{- end }}
   labels:
-    theketch.io/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
   name: {{ $.Values.app.name }}-http
 spec:
-    hosts: 
+    hosts:
     {{- if  $.Values.app.ingress.http }}
     {{- range $_, $cname := .Values.app.ingress.http }}
     - {{ $cname }}
@@ -22,11 +22,11 @@ spec:
     - {{ $https.cname }}
     {{- end }}
     {{- end }}
-    gateways: 
+    gateways:
     - {{ $.Values.app.name }}-http-gateway
     http:
     - route:
-      {{- range $_, $deployment := $.Values.app.deployments }} 
+      {{- range $_, $deployment := $.Values.app.deployments }}
         {{- range $_, $process := $deployment.processes }}
         {{- if $process.routable }}{{- if gt $deployment.routingSettings.weight 0.0}}
         - destination:

--- a/internal/templates/traefik/yamls/ingressroute.yaml
+++ b/internal/templates/traefik/yamls/ingressroute.yaml
@@ -12,7 +12,7 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.ingressController.clusterIssuer }}
     {{- end }}
   labels:
-    theketch.io/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
 spec:
   entryPoints:
     - web
@@ -27,11 +27,11 @@ spec:
     - name: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
       port: {{ $process.publicServicePort }}
       weight: {{$deployment.routingSettings.weight}}
-      {{- end }}   
-      {{- end }}   
-      {{- end }}  
-  {{- end }}   
-  {{- end }} 
+      {{- end }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 ---
 {{- end }}
@@ -50,7 +50,7 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.ingressController.clusterIssuer }}
     {{- end }}
   labels:
-    theketch.io/app-name: {{ $.Values.app.name }}
+    {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
 spec:
   entryPoints:
     - websecure
@@ -64,14 +64,14 @@ spec:
      {{- if $process.routable }}{{- if gt $deployment.routingSettings.weight 0.0}}
     - name: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
       port: {{ $process.publicServicePort }}
-      weight: {{$deployment.routingSettings.weight}}  
-      {{- end }}   
-      {{- end }}   
-      {{- end }}   
-  {{- end }}   
-  {{- end }}  
+      weight: {{$deployment.routingSettings.weight}}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
   tls:
-  {{- range $_, $https := .Values.app.ingress.https }} 
+  {{- range $_, $https := .Values.app.ingress.https }}
     secretName: {{ $https.secretName }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

Makes app's labels configurable with `--group`.

My editor's linter cleaned up a few stray spaces.

Fixes # [1889](https://shipaio.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=SHIPA&modal=detail&selectedIssue=SHIPA-1889)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

