### PR TITLE
Shipa 1875

### DIFF
--- a/config/crd/bases/theketch.io_frameworks.yaml
+++ b/config/crd/bases/theketch.io_frameworks.yaml
@@ -49,6 +49,10 @@ spec:
           spec:
             description: FrameworkSpec defines the desired state of Framework
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
               appQuotaLimit:
                 type: integer
               ingressController:
@@ -70,6 +74,10 @@ spec:
                     type: string
                 required:
                 - type
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
                 type: object
               name:
                 type: string

--- a/internal/api/v1beta1/framework_types.go
+++ b/internal/api/v1beta1/framework_types.go
@@ -61,6 +61,10 @@ type FrameworkSpec struct {
 
 	AppQuotaLimit *int `json:"appQuotaLimit"`
 
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	Labels map[string]string `json:"labels,omitempty"`
+
 	IngressController IngressControllerSpec `json:"ingressController,omitempty"`
 }
 

--- a/internal/controllers/framework_controller.go
+++ b/internal/controllers/framework_controller.go
@@ -46,9 +46,9 @@ type FrameworkReconciler struct {
 
 func (r *FrameworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("framework", req.NamespacedName)
-
 	framework := ketchv1.Framework{}
 	if err := r.Get(ctx, req.NamespacedName, &framework); err != nil {
+
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -59,7 +59,16 @@ func (r *FrameworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, err
 }
 
+func cleanAndUpdateMap(ns *map[string]string, current map[string]string) {
+	*ns = map[string]string{}
+	// directly setting equal will add to error when trying to add the istio-injection key
+	for k, v := range current {
+		(*ns)[k] = v
+	}
+}
+
 func (r *FrameworkReconciler) reconcile(ctx context.Context, framework *ketchv1.Framework) ketchv1.FrameworkStatus {
+
 	frameworks := ketchv1.FrameworkList{}
 	err := r.List(ctx, &frameworks)
 	if err != nil {
@@ -72,6 +81,7 @@ func (r *FrameworkReconciler) reconcile(ctx context.Context, framework *ketchv1.
 		}
 	}
 	namespace := v1.Namespace{}
+
 	failures := 0
 	for {
 		err := r.Get(ctx, types.NamespacedName{Name: framework.Spec.NamespaceName}, &namespace)
@@ -110,14 +120,15 @@ func (r *FrameworkReconciler) reconcile(ctx context.Context, framework *ketchv1.
 			time.Sleep(1 * time.Second)
 		}
 	}
+
+	cleanAndUpdateMap(&namespace.Annotations, framework.Spec.Annotations)
+	cleanAndUpdateMap(&namespace.Labels, framework.Spec.Labels)
+
 	// we rely on istio automatic sidecar injection
 	// https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection
 	istioInjectionValue := "disabled"
 	if framework.Spec.IngressController.IngressType == ketchv1.IstioIngressControllerType {
 		istioInjectionValue = "enabled"
-	}
-	if namespace.Labels == nil {
-		namespace.Labels = map[string]string{}
 	}
 	namespace.Labels["istio-injection"] = istioInjectionValue
 

--- a/internal/controllers/framework_controller.go
+++ b/internal/controllers/framework_controller.go
@@ -61,7 +61,7 @@ func (r *FrameworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 func cleanAndUpdateMap(ns *map[string]string, current map[string]string) {
 	*ns = map[string]string{}
-	// directly setting equal will add to error when trying to add the istio-injection key
+	// directly setting ns as current will cause an error when trying to add the istio-injection key
 	for k, v := range current {
 		(*ns)[k] = v
 	}

--- a/internal/controllers/framework_controller.go
+++ b/internal/controllers/framework_controller.go
@@ -59,14 +59,6 @@ func (r *FrameworkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, err
 }
 
-func cleanAndUpdateMap(ns *map[string]string, current map[string]string) {
-	*ns = map[string]string{}
-	// directly setting ns as current will cause an error when trying to add the istio-injection key
-	for k, v := range current {
-		(*ns)[k] = v
-	}
-}
-
 func (r *FrameworkReconciler) reconcile(ctx context.Context, framework *ketchv1.Framework) ketchv1.FrameworkStatus {
 
 	frameworks := ketchv1.FrameworkList{}
@@ -121,8 +113,15 @@ func (r *FrameworkReconciler) reconcile(ctx context.Context, framework *ketchv1.
 		}
 	}
 
-	cleanAndUpdateMap(&namespace.Annotations, framework.Spec.Annotations)
-	cleanAndUpdateMap(&namespace.Labels, framework.Spec.Labels)
+	namespace.Annotations = framework.Spec.Annotations
+	if namespace.Annotations == nil {
+		namespace.Annotations = map[string]string{}
+	}
+
+	namespace.Labels = framework.Spec.Labels
+	if namespace.Labels == nil {
+		namespace.Labels = map[string]string{}
+	}
 
 	// we rely on istio automatic sidecar injection
 	// https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection

--- a/internal/controllers/framework_controller_test.go
+++ b/internal/controllers/framework_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -143,7 +142,6 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatusPhase, resultFramework.Status.Phase)
 			assert.Equal(t, tt.wantStatusMessage, resultFramework.Status.Message)
-			fmt.Println(resultFramework)
 
 			if tt.wantStatusPhase == ketchv1.FrameworkCreated {
 				assert.NotNil(t, resultFramework.Status.Namespace.Name)
@@ -151,7 +149,6 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 
 				gotNamespace := v1.Namespace{}
 				err = ctx.k8sClient.Get(context.TODO(), types.NamespacedName{Name: tt.framework.Spec.NamespaceName}, &gotNamespace)
-				fmt.Println(gotNamespace)
 				assert.Equal(t, tt.wantNamespaceLabels, gotNamespace.Labels)
 				assert.Equal(t, tt.wantNamespaceAnnotations, gotNamespace.Annotations)
 			} else {

--- a/internal/controllers/framework_controller_test.go
+++ b/internal/controllers/framework_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -41,6 +42,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 		wantStatusPhase          ketchv1.FrameworkPhase
 		wantStatusMessage        string
 		wantNamespaceAnnotations map[string]string
+		wantNamespaceLabels      map[string]string
 	}{
 		{
 			name: "namespace is used by another framework",
@@ -74,7 +76,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			wantStatusPhase: ketchv1.FrameworkCreated,
-			wantNamespaceAnnotations: map[string]string{
+			wantNamespaceLabels: map[string]string{
 				"istio-injection": "enabled",
 			},
 		},
@@ -93,8 +95,33 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			wantStatusPhase: ketchv1.FrameworkCreated,
-			wantNamespaceAnnotations: map[string]string{
+			wantNamespaceLabels: map[string]string{
 				"istio-injection": "disabled",
+			},
+		},
+		{
+			name: "framework annotations and labels added to namespace",
+			framework: ketchv1.Framework{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "framework-5",
+				},
+				Spec: ketchv1.FrameworkSpec{
+					AppQuotaLimit: conversions.IntPtr(1),
+					Annotations:   map[string]string{"test-annotation": "value"},
+					Labels:        map[string]string{"test-label": "value"},
+					NamespaceName: "another-namespace-5",
+					IngressController: ketchv1.IngressControllerSpec{
+						IngressType: ketchv1.IstioIngressControllerType,
+					},
+				},
+			},
+			wantStatusPhase: ketchv1.FrameworkCreated,
+			wantNamespaceAnnotations: map[string]string{
+				"test-annotation": "value",
+			},
+			wantNamespaceLabels: map[string]string{
+				"test-label":      "value",
+				"istio-injection": "enabled",
 			},
 		},
 	}
@@ -116,6 +143,7 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatusPhase, resultFramework.Status.Phase)
 			assert.Equal(t, tt.wantStatusMessage, resultFramework.Status.Message)
+			fmt.Println(resultFramework)
 
 			if tt.wantStatusPhase == ketchv1.FrameworkCreated {
 				assert.NotNil(t, resultFramework.Status.Namespace.Name)
@@ -123,10 +151,128 @@ func TestFrameworkReconciler_Reconcile(t *testing.T) {
 
 				gotNamespace := v1.Namespace{}
 				err = ctx.k8sClient.Get(context.TODO(), types.NamespacedName{Name: tt.framework.Spec.NamespaceName}, &gotNamespace)
-				assert.Equal(t, tt.wantNamespaceAnnotations, gotNamespace.Labels)
+				fmt.Println(gotNamespace)
+				assert.Equal(t, tt.wantNamespaceLabels, gotNamespace.Labels)
+				assert.Equal(t, tt.wantNamespaceAnnotations, gotNamespace.Annotations)
 			} else {
 				assert.Nil(t, resultFramework.Status.Namespace)
 			}
+		})
+	}
+}
+
+func TestFrameworkReconciler_ReconcileUpdate(t *testing.T) {
+	defaultObjects := []client.Object{
+		&ketchv1.Framework{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-framework",
+			},
+			Spec: ketchv1.FrameworkSpec{
+				Annotations: map[string]string{
+					"remove-after-update": "value",
+					"keep-after-update":   "value",
+				},
+				Labels: map[string]string{
+					"remove-after-update": "value",
+					"keep-after-update":   "value",
+				},
+				NamespaceName: "default-namespace",
+				AppQuotaLimit: conversions.IntPtr(100),
+				IngressController: ketchv1.IngressControllerSpec{
+					IngressType: ketchv1.IstioIngressControllerType,
+				},
+			},
+		},
+	}
+	ctx, err := setup(nil, nil, defaultObjects)
+	assert.Nil(t, err)
+
+	defer teardown(ctx)
+	updatedAnnotations := map[string]string{
+		"keep-after-update": "value",
+	}
+	updatedLabels := map[string]string{
+		"keep-after-update": "value",
+	}
+
+	tests := []struct {
+		name                  string
+		frameworkName         string
+		namespaceName         string
+		wantStatusPhase       ketchv1.FrameworkPhase
+		wantStatusMessage     string
+		preUpdateAnnotations  map[string]string
+		preUpdateLabels       map[string]string
+		postUpdateAnnotations map[string]string
+		postUpdateLabels      map[string]string
+	}{
+		{
+			name:            "Updating framework annotations/labels is reflected in namespace",
+			frameworkName:   "default-framework",
+			namespaceName:   "default-namespace",
+			wantStatusPhase: ketchv1.FrameworkCreated,
+			preUpdateAnnotations: map[string]string{
+				"remove-after-update": "value",
+				"keep-after-update":   "value",
+			},
+			preUpdateLabels: map[string]string{
+				"remove-after-update": "value",
+				"keep-after-update":   "value",
+				"istio-injection":     "enabled",
+			},
+			postUpdateAnnotations: map[string]string{
+				"keep-after-update": "value",
+			},
+			postUpdateLabels: map[string]string{
+				"keep-after-update": "value",
+				"istio-injection":   "enabled",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			resultFramework := ketchv1.Framework{}
+			for {
+				time.Sleep(250 * time.Millisecond)
+				err = ctx.k8sClient.Get(context.TODO(), types.NamespacedName{Name: tt.frameworkName}, &resultFramework)
+				assert.Nil(t, err)
+				if len(resultFramework.Status.Phase) > 0 {
+					break
+				}
+			}
+			gotNamespace := v1.Namespace{}
+			err = ctx.k8sClient.Get(context.TODO(), types.NamespacedName{Name: tt.namespaceName}, &gotNamespace)
+			assert.Equal(t, tt.preUpdateLabels, gotNamespace.Labels)
+			assert.Equal(t, tt.preUpdateAnnotations, gotNamespace.Annotations)
+
+			resultFramework.Spec.Labels = updatedLabels
+			resultFramework.Spec.Annotations = updatedAnnotations
+
+			err := ctx.k8sClient.Update(context.TODO(), &resultFramework)
+			assert.Nil(t, err)
+
+			resultFramework = ketchv1.Framework{}
+			for {
+				time.Sleep(250 * time.Millisecond)
+				err = ctx.k8sClient.Get(context.TODO(), types.NamespacedName{Name: tt.frameworkName}, &resultFramework)
+				assert.Nil(t, err)
+				if len(resultFramework.Status.Phase) > 0 {
+					break
+				}
+			}
+
+			assert.Equal(t, tt.wantStatusPhase, resultFramework.Status.Phase)
+			assert.Equal(t, tt.wantStatusMessage, resultFramework.Status.Message)
+
+			assert.NotNil(t, resultFramework.Status.Namespace.Name)
+			assert.NotNil(t, resultFramework.Status.Namespace.UID)
+
+			gotNamespace = v1.Namespace{}
+			err = ctx.k8sClient.Get(context.TODO(), types.NamespacedName{Name: tt.namespaceName}, &gotNamespace)
+			assert.Equal(t, tt.postUpdateLabels, gotNamespace.Labels)
+			assert.Equal(t, tt.postUpdateAnnotations, gotNamespace.Annotations)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Extend Framework CRD to include annotations and labels. Make sure that these labels and annotations are added to the namespace and that ones not present in the newest framework aren't included.

To test install ketch using this branch and create a framework. Add annotations/labels with `kubectl edit framework`, after saving and exiting confirm the annotations/labels have also been added to the corresponding namespace by running `kubectl describe namespace <namespace-name>`. This process can be repeated any number of times to see how changes in the framework affect the corresponding namespace.

Fixes # 1875

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
