### PR TITLE
[SHIPA-1943] Makes CName schemes configurable

### DIFF
--- a/cmd/ketch/app_info_test.go
+++ b/cmd/ketch/app_info_test.go
@@ -89,7 +89,7 @@ func Test_appInfo(t *testing.T) {
 			Framework: "aws",
 			Ingress: ketchv1.IngressSpec{
 				GenerateDefaultCname: true,
-				Cnames:               []string{"theketch.io", "www.theketch.io"},
+				Cnames:               ketchv1.CnameList{{Name: "theketch.io"}, {Name: "www.theketch.io"}},
 			},
 			DockerRegistry: ketchv1.DockerRegistrySpec{
 				SecretName: "go-app-pull-credentials",

--- a/cmd/ketch/app_list_test.go
+++ b/cmd/ketch/app_list_test.go
@@ -23,7 +23,7 @@ func Test_appList(t *testing.T) {
 			Framework:   "fw1",
 			Ingress: ketchv1.IngressSpec{
 				GenerateDefaultCname: false,
-				Cnames:               []string{"app-a-cname1"},
+				Cnames:               ketchv1.CnameList{{Name: "app-a-cname1"}},
 			},
 			Builder: "",
 		},
@@ -38,7 +38,7 @@ func Test_appList(t *testing.T) {
 			Framework:   "fw1",
 			Ingress: ketchv1.IngressSpec{
 				GenerateDefaultCname: false,
-				Cnames:               []string{"app-b-cname1"},
+				Cnames:               ketchv1.CnameList{{Name: "app-b-cname1"}},
 			},
 			Builder: "",
 		},

--- a/cmd/ketch/cname_remove.go
+++ b/cmd/ketch/cname_remove.go
@@ -46,9 +46,9 @@ func cnameRemove(ctx context.Context, cfg config, options cnameRemoveOptions, ou
 	if err := cfg.Client().Get(ctx, types.NamespacedName{Name: options.appName}, &app); err != nil {
 		return fmt.Errorf("failed to get the app: %w", err)
 	}
-	cnames := make([]string, 0, len(app.Spec.Ingress.Cnames))
+	cnames := make(ketchv1.CnameList, 0, len(app.Spec.Ingress.Cnames))
 	for _, cname := range app.Spec.Ingress.Cnames {
-		if cname == options.cname {
+		if cname.Name == options.cname {
 			continue
 		}
 		cnames = append(cnames, cname)

--- a/cmd/ketch/errors.go
+++ b/cmd/ketch/errors.go
@@ -22,6 +22,8 @@ const (
 	ErrLogUnknownTimeFormat cliError = "unknown time format"
 
 	ErrClusterIssuerNotFound cliError = "cluster issuer not found"
+
+	ErrClusterIssuerRequired cliError = "secure cnames require framework.IngressController.ClusterIssuer to be set"
 )
 
 func unwrappedError(err error) error {

--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -2251,7 +2251,15 @@ spec:
                   cnames:
                     description: Cnames is a list of additional cnames.
                     items:
-                      type: string
+                      properties:
+                        name:
+                          type: string
+                        secure:
+                          type: boolean
+                      required:
+                      - name
+                      - secure
+                      type: object
                     type: array
                   generateDefaultCname:
                     description: GenerateDefaultCname if set the application will

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -54,6 +54,7 @@ type Label struct {
 // CnameList is a list of an app's CNAMEs.
 type CnameList []Cname
 
+// Cname represents a DNS record and whether the record use TLS.
 type Cname struct {
 	Name   string `json:"name"`
 	Secure bool   `json:"secure"`

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -52,7 +52,12 @@ type Label struct {
 }
 
 // CnameList is a list of an app's CNAMEs.
-type CnameList []string
+type CnameList []Cname
+
+type Cname struct {
+	Name   string `json:"name"`
+	Secure bool   `json:"secure"`
+}
 
 // RoutingSettings contains a weight of the current deployment used to route incoming traffic.
 // If an application has two deployments with corresponding weights of 30 and 70,
@@ -379,17 +384,17 @@ func (app *App) Start(selector Selector) error {
 
 // CNames returns all CNAMEs to access the application including a default cname.
 func (app *App) CNames(framework *Framework) []string {
-	scheme := "http"
-	if len(framework.Spec.IngressController.ClusterIssuer) > 0 {
-		scheme = "https"
-	}
 	cnames := []string{}
 	defaultCname := app.DefaultCname(framework)
 	if defaultCname != nil {
 		cnames = append(cnames, fmt.Sprintf("http://%s", *defaultCname))
 	}
 	for _, cname := range app.Spec.Ingress.Cnames {
-		cnames = append(cnames, fmt.Sprintf("%s://%s", scheme, cname))
+		scheme := "http"
+		if cname.Secure {
+			scheme = "https"
+		}
+		cnames = append(cnames, fmt.Sprintf("%s://%s", scheme, cname.Name))
 	}
 	return cnames
 }

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -433,28 +433,28 @@ func TestApp_CNames(t *testing.T) {
 		name                 string
 		generateDefaultCname bool
 		framework            Framework
-		cnames               []string
+		cnames               []Cname
 		want                 []string
 	}{
 		{
 			name:                 "with default cname",
 			generateDefaultCname: true,
 			framework:            framework,
-			cnames:               []string{"theketch.io", "app.theketch.io"},
+			cnames:               []Cname{{Name: "theketch.io"}, {Name: "app.theketch.io"}},
 			want:                 []string{"http://ketch.10.20.30.40.shipa.cloud", "http://theketch.io", "http://app.theketch.io"},
 		},
 		{
 			name:                 "with default cname and framework with cluster issuer",
 			generateDefaultCname: true,
 			framework:            frameworkWithClusterIssuer,
-			cnames:               []string{"theketch.io", "app.theketch.io"},
-			want:                 []string{"http://ketch.10.20.30.40.shipa.cloud", "https://theketch.io", "https://app.theketch.io"},
+			cnames:               []Cname{{Name: "theketch.io"}, {Name: "app.theketch.io", Secure: true}},
+			want:                 []string{"http://ketch.10.20.30.40.shipa.cloud", "http://theketch.io", "https://app.theketch.io"},
 		},
 		{
 			name:                 "without default cname",
 			generateDefaultCname: false,
 			framework:            framework,
-			cnames:               []string{"theketch.io", "app.theketch.io"},
+			cnames:               []Cname{{Name: "theketch.io"}, {Name: "app.theketch.io"}},
 			want:                 []string{"http://theketch.io", "http://app.theketch.io"},
 		},
 		{

--- a/internal/chart/application_chart_test.go
+++ b/internal/chart/application_chart_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/kube/fake"
@@ -21,7 +22,7 @@ import (
 	"github.com/shipa-corp/ketch/internal/utils/conversions"
 )
 
-func TestNew(t *testing.T) {
+func TestNewApplicationChart(t *testing.T) {
 
 	const chartDirectory = "./testdata/charts/"
 
@@ -133,7 +134,15 @@ func TestNew(t *testing.T) {
 			},
 			Ingress: ketchv1.IngressSpec{
 				GenerateDefaultCname: true,
-				Cnames:               []string{"theketch.io", "app.theketch.io"},
+				Cnames: []ketchv1.Cname{
+					{
+						Name:   "theketch.io",
+						Secure: true,
+					}, {
+						Name:   "app.theketch.io",
+						Secure: true,
+					},
+				},
 			},
 			Labels: []ketchv1.MetadataItem{{
 				Apply:             map[string]string{"theketch.io/test-label": "test-label-value"},
@@ -162,6 +171,16 @@ func TestNew(t *testing.T) {
 		},
 	}
 
+	// convertSecureEndpoints returns a copy of app with Cnames made not secure
+	convertSecureEndpoints := func(app *ketchv1.App) *ketchv1.App {
+		out := *app
+		out.Spec.Ingress.Cnames = []ketchv1.Cname{}
+		for _, cname := range app.Spec.Ingress.Cnames {
+			out.Spec.Ingress.Cnames = append(out.Spec.Ingress.Cnames, ketchv1.Cname{Name: cname.Name, Secure: false})
+		}
+		return &out
+	}
+
 	tests := []struct {
 		name        string
 		application *ketchv1.App
@@ -188,7 +207,7 @@ func TestNew(t *testing.T) {
 				WithTemplates(templates.IstioDefaultTemplates),
 				WithExposedPorts(exportedPorts),
 			},
-			application:       dashboard,
+			application:       convertSecureEndpoints(dashboard),
 			framework:         frameworkWithoutClusterIssuer,
 			wantYamlsFilename: "dashboard-istio",
 		},
@@ -208,7 +227,7 @@ func TestNew(t *testing.T) {
 				WithTemplates(templates.TraefikDefaultTemplates),
 				WithExposedPorts(exportedPorts),
 			},
-			application:       dashboard,
+			application:       convertSecureEndpoints(dashboard),
 			framework:         frameworkWithoutClusterIssuer,
 			wantYamlsFilename: "dashboard-traefik",
 		},
@@ -271,6 +290,82 @@ func TestNew(t *testing.T) {
 			expected, err := ioutil.ReadFile(expectedFilename)
 			require.Nil(t, err)
 			require.Equal(t, string(expected), actualManifests)
+		})
+	}
+}
+
+func TestNewIngress(t *testing.T) {
+	tests := []struct {
+		name          string
+		cnames        ketchv1.CnameList
+		clusterIssuer string
+		expected      *ingress
+		expectedError error
+	}{
+		{
+			name: "happy",
+			cnames: ketchv1.CnameList{
+				{
+					Name:   "a.name",
+					Secure: true,
+				},
+				{
+					Name: "b.name",
+				},
+			},
+			clusterIssuer: "test-cluster-issuer",
+			expected: &ingress{
+				Https: []httpsEndpoint{{Cname: "a.name", SecretName: "-cname-2bffdc1c076b2cc72660"}},
+				Http:  []string{"b.name"},
+			},
+		},
+		{
+			name: "happy - no https, no cluster issuer",
+			cnames: ketchv1.CnameList{
+				{
+					Name: "a.name",
+				},
+				{
+					Name: "b.name",
+				},
+			},
+			expected: &ingress{
+				Http: []string{"a.name", "b.name"},
+			},
+		},
+		{
+			name: "sad - no cluster issuer",
+			cnames: ketchv1.CnameList{
+				{
+					Name:   "a.name",
+					Secure: true,
+				},
+			},
+			expectedError: errors.New("secure cnames require a framework.Ingress.ClusterIssuer to be specified"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := ketchv1.App{
+				Spec: ketchv1.AppSpec{
+					Ingress: ketchv1.IngressSpec{
+						Cnames: tt.cnames,
+					},
+				},
+			}
+			framework := ketchv1.Framework{
+				Spec: ketchv1.FrameworkSpec{
+					IngressController: ketchv1.IngressControllerSpec{
+						ClusterIssuer: tt.clusterIssuer,
+					},
+				},
+			}
+			issuer, err := newIngress(app, framework)
+			if tt.expectedError != nil {
+				require.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				require.Equal(t, tt.expected, issuer)
+			}
 		})
 	}
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -200,6 +200,10 @@ func deployImage(ctx context.Context, svc *Services, app *ketchv1.App, params *C
 		return errors.Wrap(err, "failed to get framework %q", app.Spec.Framework)
 	}
 
+	if len(framework.Spec.IngressController.ClusterIssuer) == 0 && params.hasSecureCnames() {
+		return errors.New("secure cnames require a framework.Ingress.ClusterIssuer to be specified")
+	}
+
 	image, _ := params.getImage()
 
 	fromSource := params.sourcePath != nil

--- a/internal/deploy/parameters.go
+++ b/internal/deploy/parameters.go
@@ -410,3 +410,15 @@ func (c *ChangeSet) getKetchYaml() (*ketchv1.KetchYamlData, error) {
 	}
 	return data, nil
 }
+
+func (cs *ChangeSet) hasSecureCnames() bool {
+	if cs.cname == nil {
+		return false
+	}
+	for _, cname := range *cs.cname {
+		if cname.Secure {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/deploy/yaml.go
+++ b/internal/deploy/yaml.go
@@ -51,6 +51,7 @@ type Restart struct {
 
 type CName struct {
 	DNSName string `json:"dnsName"`
+	Secure  bool   `json:"secure"`
 }
 
 const (
@@ -107,7 +108,7 @@ func (o *Options) GetChangeSetFromYaml(filename string) (*ChangeSet, error) {
 		c.sourcePath = &o.AppSourcePath
 	}
 	if application.CName != nil {
-		c.cname = &ketchv1.CnameList{application.CName.DNSName}
+		c.cname = &ketchv1.CnameList{{Name: application.CName.DNSName, Secure: application.CName.Secure}}
 	}
 	if application.Environment != nil {
 		c.envs = &application.Environment
@@ -180,7 +181,8 @@ func GetApplicationFromKetchApp(app ketchv1.App) *Application {
 
 	if len(app.Spec.Ingress.Cnames) > 0 {
 		application.CName = &CName{
-			DNSName: app.Spec.Ingress.Cnames[0],
+			DNSName: app.Spec.Ingress.Cnames[0].Name,
+			Secure:  app.Spec.Ingress.Cnames[0].Secure,
 		}
 	}
 	if app.Spec.Description != "" {

--- a/internal/deploy/yaml_test.go
+++ b/internal/deploy/yaml_test.go
@@ -56,7 +56,7 @@ cname:
 				dockerRegistrySecret: nil,
 				builder:              conversions.StrPtr("heroku/buildpacks:20"),
 				buildPacks:           &[]string{"test-buildpack"},
-				cname:                &ketchv1.CnameList{"test.10.10.10.20"},
+				cname:                &ketchv1.CnameList{{Name: "test.10.10.10.20", Secure: false}},
 				timeout:              conversions.StrPtr("1m"),
 				wait:                 conversions.BoolPtr(true),
 				processes: &[]ketchv1.ProcessSpec{
@@ -275,7 +275,7 @@ func TestGetApplicationFromKetchApp(t *testing.T) {
 							Image:   "gcr.io/shipa-ci/sample-go-app:not_latest",
 						},
 					},
-					Ingress: ketchv1.IngressSpec{Cnames: []string{"test.com", "another.com"}},
+					Ingress: ketchv1.IngressSpec{Cnames: ketchv1.CnameList{{Name: "test.com"}, {Name: "another.com"}}},
 				},
 			},
 			application: &Application{


### PR DESCRIPTION
# Description

Makes the http/https scheme configurable per Cname. Switches `app.ingress.cnames` from `[]string` to `[]Cname{Name: <string>, Secure: <bool>}`. 
This change is backward compatible with:
- Using the CLI. Cnames were added with the `ketch cname add` command. I added a `--secure` flag. It will return a user error if you specify `secure` and the app's framework does not have a clusterIssuer. 
- Using app.yamls. Deploying a ketch app by yaml only permits **one** cname (probably worth changing in a new issue). I added a `secure` field to the `cname` object. 
  ```
  cname:
    dnsName: secure.10.96.13.219.shipa.cloud
    secure: true
  ```
  It will return user error if you specify `secure` and a framework without a cluster issuer. 

This PR changes what users will supply in a kubernetes config file. Cnames are an object rather than string. E.g. 
```
apiVersion: theketch.io/v1beta1
kind: App
metadata:
  name: test
  namespace: foobar
spec:
  canary: {}
  deployments:
  - image: gcr.io/kubernetes-312803/sample-go-app:latest
    processes:
    - cmd:
      - web
      name: web
      units: 1
    routingSettings:
      weight: 100
    version: 1
    labels:
      - name: test-label
        value: works
  deploymentsCount: 1
  dockerRegistry: {}
  framework: test
  ingress:
    generateDefaultCname: false
    cnames:
      - name: secure.10.96.13.219.shipa.cloud
        secure: true
      - name: insecure.10.96.13.219.shipa.cloud
        secure: false
```

Fixes # [1943](https://shipaio.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=SHIPA&modal=detail&selectedIssue=SHIPA-1943)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

