### PR TITLE
Scale target deployment for canary

### DIFF
--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -113,6 +113,11 @@ spec:
                     maximum: 100
                     minimum: 0
                     type: integer
+                  target:
+                    additionalProperties:
+                      type: integer
+                    description: Target map of processes and target units value
+                    type: object
                 type: object
               deployments:
                 description: Deployments is a list of running deployments.

--- a/internal/api/v1beta1/app_types_test.go
+++ b/internal/api/v1beta1/app_types_test.go
@@ -8,6 +8,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -1188,7 +1189,7 @@ func TestApp_DoCanary(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.app.DoCanary(tt.now)
+			err := tt.app.DoCanary(tt.now, logr.Discard())
 			originalApp := *tt.app.DeepCopy()
 			if len(tt.wantErr) > 0 {
 				require.NotNil(t, err)


### PR DESCRIPTION
# Description

Scale process' units based on the current weight of deployment and specified target values per process. The `Target` map has been added to the `CanarySpec`, which is used to specify the target number of units per process. During the canary deployment, the two deployments' processes should add up to the target value (per process). The final deployment should have the same value as the target (per process).

In the previous deployment, if a process is not present in the target, the number of units will not be affected during the canary deployment, but will end up being removed (along with the rest of the deployment) if the canary deployment successfully completes.

In the updated deployment, if a process is not present in the target list, the process will be given a default value of 1.

To test the code, deploy this branch's controller, and create an app with the bulletin board app.
`ketch app deploy <app> --framework myframework -i docker.io/shipasoftware/bulletinboard:1.0`
Once the app has been successfully deployed, run the command: `kubectl edit app <app>`, and paste in the following code (making sure to delete the previous values!):

*Please make sure to change the `nextScheduledTime` to an appropriate value!
```
spec:
  canary:
    active: true
    nextScheduledTime: "2021-09-28T16:38:46Z"
    started: "2021-09-28T16:36:46Z"
    stepTimeInterval: 120000000000
    stepWeight: 16
    steps: 6
    target:
      web: 10
  deployments:
  - exposedPorts:
    - port: 8080
      protocol: TCP
    image: docker.io/shipasoftware/bulletinboard:1.0
    processes:
    - cmd:
      - docker-entrypoint.sh
      - npm
      - start
      name: web
      units: 1
    routingSettings:
      weight: 100
    version: 1
  - exposedPorts:
    - port: 8080
      protocol: TCP
    image: docker.io/shipasoftware/bulletinboard:1.0
    processes:
    - cmd:
      - docker-entrypoint.sh
      - npm
      - start
      name: web
      units: 1
    routingSettings:
      weight: 0
    version: 2
  deploymentsCount: 2
```

After editing the code, save and exit. The above deployment will run in 6 steps, maintaining 10 units of the process `web` between the two deployments. You can view this behavior by listing all pods `kubectl get pods -A` or by checking the app's description `kubectl describe app <app>`.

Feel free to test images with multiple processes as well, editing the map to see how each process is affected.

Fixes # 1884

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

## Additional Information (omit if empty)

Please include anything else relevant to this PR that may be useful to know.
