### PR TITLE
Build ketch:<commit> image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,17 @@ jobs:
         - docker build -t shipasoftware/ketch:$TRAVIS_COMMIT .
         - docker push shipasoftware/ketch:$TRAVIS_COMMIT
 
+    - stage: build
+      branches:
+        only:
+          - master
+      language: bash
+      sudo: required
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+        - docker build -t shipasoftware/ketch:$TRAVIS_COMMIT .
+        - docker push shipasoftware/ketch:$TRAVIS_COMMIT
+
     - stage: test
       sudo: required
       name: "Running integration tests"


### PR DESCRIPTION
It would be great to be able to use ketch's image built from `main` branch
