### PR TITLE
Broaden check on api version when applying labels & annotations

### DIFF
--- a/internal/chart/process.go
+++ b/internal/chart/process.go
@@ -199,7 +199,7 @@ func withAnnotations(annotations []ketchv1.MetadataItem, deploymentVersion ketch
 // item.ProcessName is unspecified OR matches processName
 // item.Target.ApiVersion is v1
 func canBeApplied(item ketchv1.MetadataItem, processName string, version ketchv1.DeploymentVersion) bool {
-	if item.Target.APIVersion != "v1" {
+	if !strings.Contains(item.Target.APIVersion, "v1") {
 		return false
 	}
 	if item.DeploymentVersion > 0 && int(version) != item.DeploymentVersion {

--- a/internal/chart/process_test.go
+++ b/internal/chart/process_test.go
@@ -281,7 +281,7 @@ func TestWithAnnotationsAndLabels(t *testing.T) {
 			},
 			labels: []ketchv1.MetadataItem{
 				{
-					Target:            ketchv1.Target{Kind: "Deployment", APIVersion: "v1"},
+					Target:            ketchv1.Target{Kind: "Deployment", APIVersion: "apps/v1"},
 					DeploymentVersion: 1,
 					ProcessName:       "web",
 					Apply:             map[string]string{"theketch.io/test": "value"},


### PR DESCRIPTION
# Description

Aleksej pointed out that ketch's `Deployment` `APIVersion` was `apps/v1` rather than `v1`, preventing labels and annotations from being assigned correctly to Deployments: https://github.com/shipa-corp/ketch/blob/main/internal/templates/common/yamls/deployment.yaml#L3. This PR makes the check a little broader.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [ ] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
