### PR TITLE
Put values of annotations and labels in quotes

### DIFF
--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -79,7 +79,7 @@ metadata:
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
   annotations:
-    theketch.io/test-annotation: test-annotation-value
+    theketch.io/test-annotation: "test-annotation-value"
   name: dashboard-web-4
 spec:
   type: ClusterIP
@@ -129,8 +129,8 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label: test-label-value
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label: "test-label-value"
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-3
 spec:
   replicas: 3
@@ -199,7 +199,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-3
 spec:
   replicas: 1
@@ -249,7 +249,7 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-4
 spec:
   replicas: 3
@@ -298,7 +298,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-4
 spec:
   replicas: 1

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -79,7 +79,7 @@ metadata:
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
   annotations:
-    theketch.io/test-annotation: test-annotation-value
+    theketch.io/test-annotation: "test-annotation-value"
   name: dashboard-web-4
 spec:
   type: ClusterIP
@@ -129,8 +129,8 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label: test-label-value
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label: "test-label-value"
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-3
 spec:
   replicas: 3
@@ -199,7 +199,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-3
 spec:
   replicas: 1
@@ -249,7 +249,7 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-4
 spec:
   replicas: 3
@@ -298,7 +298,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-4
 spec:
   replicas: 1

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -79,7 +79,7 @@ metadata:
     shipa.io/app-deployment-version: "4"
     shipa.io/is-isolated-run: "false"
   annotations:
-    theketch.io/test-annotation: test-annotation-value
+    theketch.io/test-annotation: "test-annotation-value"
   name: dashboard-web-4
 spec:
   type: ClusterIP
@@ -129,8 +129,8 @@ metadata:
     shipa.io/app-process-replicas: "3"
     shipa.io/app-deployment-version: "3"
     shipa.io/is-isolated-run: "false"
-    theketch.io/test-label: test-label-value
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label: "test-label-value"
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-3
 spec:
   replicas: 3
@@ -199,7 +199,7 @@ metadata:
     shipa.io/app-process-replicas: "1"
     shipa.io/app-deployment-version: "3"
     shipa.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-3
 spec:
   replicas: 1
@@ -249,7 +249,7 @@ metadata:
     shipa.io/app-process-replicas: "3"
     shipa.io/app-deployment-version: "4"
     shipa.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-4
 spec:
   replicas: 3
@@ -298,7 +298,7 @@ metadata:
     shipa.io/app-process-replicas: "1"
     shipa.io/app-deployment-version: "4"
     shipa.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-4
 spec:
   replicas: 1

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -79,7 +79,7 @@ metadata:
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
   annotations:
-    theketch.io/test-annotation: test-annotation-value
+    theketch.io/test-annotation: "test-annotation-value"
   name: dashboard-web-4
 spec:
   type: ClusterIP
@@ -129,8 +129,8 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label: test-label-value
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label: "test-label-value"
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-3
 spec:
   replicas: 3
@@ -199,7 +199,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-3
 spec:
   replicas: 1
@@ -249,7 +249,7 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-4
 spec:
   replicas: 3
@@ -298,7 +298,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-4
 spec:
   replicas: 1

--- a/internal/chart/testdata/charts/dashboard-traefik.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik.yaml
@@ -79,7 +79,7 @@ metadata:
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
   annotations:
-    theketch.io/test-annotation: test-annotation-value
+    theketch.io/test-annotation: "test-annotation-value"
   name: dashboard-web-4
 spec:
   type: ClusterIP
@@ -129,8 +129,8 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label: test-label-value
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label: "test-label-value"
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-3
 spec:
   replicas: 3
@@ -199,7 +199,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "3"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-3
 spec:
   replicas: 1
@@ -249,7 +249,7 @@ metadata:
     theketch.io/app-process-replicas: "3"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-web-4
 spec:
   replicas: 3
@@ -298,7 +298,7 @@ metadata:
     theketch.io/app-process-replicas: "1"
     theketch.io/app-deployment-version: "4"
     theketch.io/is-isolated-run: "false"
-    theketch.io/test-label-all: test-label-value-all
+    theketch.io/test-label-all: "test-label-value-all"
   name: dashboard-worker-4
 spec:
   replicas: 1

--- a/internal/templates/common/yamls/deployment.yaml
+++ b/internal/templates/common/yamls/deployment.yaml
@@ -11,12 +11,12 @@ metadata:
     {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
     {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $k, $v := $process.extra.deploymentMetadata.labels }}
-    {{ $k }}: "{{ $v }}"
+    {{ $k }}: {{ $v | quote }}
     {{- end}}
   {{- if $process.extra.deploymentMetadata.annotations }}
   annotations:
     {{- range $k, $v := $process.extra.deploymentMetadata.annotations }}
-    {{ $k }}: "{{ $v }}"
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
   {{- end }}
   name: {{ $.Values.app.name }}-{{ $process.name }}-{{ $deployment.version }}

--- a/internal/templates/common/yamls/deployment.yaml
+++ b/internal/templates/common/yamls/deployment.yaml
@@ -11,12 +11,12 @@ metadata:
     {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
     {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $k, $v := $process.extra.deploymentMetadata.labels }}
-    {{ $k }}: {{ $v }}
+    {{ $k }}: "{{ $v }}"
     {{- end}}
   {{- if $process.extra.deploymentMetadata.annotations }}
   annotations:
     {{- range $k, $v := $process.extra.deploymentMetadata.annotations }}
-    {{ $k }}: {{ $v }}
+    {{ $k }}: "{{ $v }}"
     {{- end }}
   {{- end }}
   name: {{ $.Values.app.name }}-{{ $process.name }}-{{ $deployment.version }}

--- a/internal/templates/common/yamls/gateway_service.yaml
+++ b/internal/templates/common/yamls/gateway_service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
     {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $i, $label := $.Values.app.Service.Deployment.labels }}
-    {{ $label.name }}: "{{ $label.value }}"
+    {{ $label.name }}: {{ $label.value | quote }}
     {{- end }}
   name: app-{{ $.Values.app.name }}
 spec:

--- a/internal/templates/common/yamls/gateway_service.yaml
+++ b/internal/templates/common/yamls/gateway_service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name }}
     {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $i, $label := $.Values.app.Service.Deployment.labels }}
-    {{ $label.name }}: {{ $label.value }}
+    {{ $label.name }}: "{{ $label.value }}"
     {{- end }}
   name: app-{{ $.Values.app.name }}
 spec:

--- a/internal/templates/common/yamls/service.yaml
+++ b/internal/templates/common/yamls/service.yaml
@@ -11,15 +11,15 @@ metadata:
     {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
     {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $i, $label := $deployment.labels }}
-    {{ $label.name }}: {{ $label.value }}
+    {{ $label.name }}: "{{ $label.value }}"
     {{- end }}
     {{- range $k, $v := $process.extra.serviceMetadata.labels }}
-    {{ $k }}: {{ $v }}
+    {{ $k }}: "{{ $v }}"
     {{- end}}
   {{- if $process.extra.serviceMetadata.annotations }}
   annotations:
     {{- range $k, $v := $process.extra.serviceMetadata.annotations }}
-    {{ $k }}: {{ $v }}
+    {{ $k }}: "{{ $v }}"
     {{- end }}
   {{- end }}
   name: {{ $.Values.app.name }}-{{ $process.name }}-{{ $deployment.version }}

--- a/internal/templates/common/yamls/service.yaml
+++ b/internal/templates/common/yamls/service.yaml
@@ -11,15 +11,15 @@ metadata:
     {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
     {{ $.Values.app.group }}/is-isolated-run: "false"
     {{- range $i, $label := $deployment.labels }}
-    {{ $label.name }}: "{{ $label.value }}"
+    {{ $label.name }}: {{ $label.value | quote }}
     {{- end }}
     {{- range $k, $v := $process.extra.serviceMetadata.labels }}
-    {{ $k }}: "{{ $v }}"
+    {{ $k }}: {{ $v | quote }}
     {{- end}}
   {{- if $process.extra.serviceMetadata.annotations }}
   annotations:
     {{- range $k, $v := $process.extra.serviceMetadata.annotations }}
-    {{ $k }}: "{{ $v }}"
+    {{ $k }}: {{ $v | quote }}
     {{- end }}
   {{- end }}
   name: {{ $.Values.app.name }}-{{ $process.name }}-{{ $deployment.version }}


### PR DESCRIPTION
   Helm fails to validate the metadata section of a k8s resource
   if there is a label or annotations without quotes like in the following example

   apiVersion: apps/v1
   kind: Deployment
   metadata:
     annotations:
       name: true


- [x] Bug fix (non-breaking change which fixes an issue)

