### PR TITLE
Add app.spec.id and DestinationRule for istio resources of app

### DIFF
--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -2249,6 +2249,15 @@ spec:
                 description: Framework is a name of a Framework used to run the application.
                 minLength: 1
                 type: string
+              id:
+                description: ID is an additional unique identifier of this application
+                  besides the app's name if needed. Ketch internally doesn't rely
+                  on this field, so it can be anything useful for a user. Ketch uses
+                  either this ID or the app name and adds "app=<ID or name>" label
+                  to all pods. ID is preferred and used if set, otherwise the label
+                  will be "app=<app-name>". Thus, istio time series will have "destination_app=<ID
+                  or name>" label.
+                type: string
               ingress:
                 description: Ingress contains configuration of entrypoints to access
                   the application.

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -229,10 +229,10 @@ type AppSpec struct {
 	// BuildPacks is a list of build packs to use when building from source.
 	BuildPacks []string `json:"buildPacks,omitempty"`
 
-	// Labels is a list of labels that will be applied to processes
+	// Labels is a list of labels that will be applied to Services/Deployments.
 	Labels []MetadataItem `json:"labels,omitempty"`
 
-	// Annotations is a list of annotations that will be applied to processes
+	// Annotations is a list of annotations that will be applied to Services/Deployments/Gateways.
 	Annotations []MetadataItem `json:"annotations,omitempty"`
 }
 

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -191,6 +191,13 @@ type CanarySpec struct {
 type AppSpec struct {
 	Version *string `json:"version,omitempty"`
 
+	// ID is an additional unique identifier of this application besides the app's name if needed.
+	// Ketch internally doesn't rely on this field, so it can be anything useful for a user.
+	// Ketch uses either this ID or the app name and adds "app=<ID or name>" label to all pods.
+	// ID is preferred and used if set, otherwise the label will be "app=<app-name>".
+	// Thus, istio time series will have "destination_app=<ID or name>" label.
+	ID string `json:"id,omitempty"`
+
 	// +kubebuilder:validation:MaxLength=140
 	Description string `json:"description,omitempty"`
 

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -13,12 +13,10 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chartutil"
-
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
-
-	"github.com/pkg/errors"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/templates"
@@ -72,8 +70,11 @@ type app struct {
 	// For example, "spec.rules" of an Ingress object must contain at least one rule.
 	IsAccessible bool   `json:"isAccessible"`
 	Group        string `json:"group"`
-
-	Service *gatewayService
+	Service      *gatewayService
+	// MetadataLabels is a list of labels to be added to k8s resources.
+	MetadataLabels []ketchv1.MetadataItem
+	// MetadataAnnotations is a list of labels to be added to k8s resources.
+	MetadataAnnotations []ketchv1.MetadataItem `json:"metadataAnnotations"`
 }
 
 type deployment struct {
@@ -140,11 +141,13 @@ func New(application *ketchv1.App, framework *ketchv1.Framework, opts ...Option)
 
 	values := &values{
 		App: &app{
-			ID:      application.Spec.ID,
-			Name:    application.Name,
-			Ingress: *ingress,
-			Env:     application.Spec.Env,
-			Group:   ketchv1.Group,
+			ID:                  application.Spec.ID,
+			Name:                application.Name,
+			Ingress:             *ingress,
+			Env:                 application.Spec.Env,
+			Group:               ketchv1.Group,
+			MetadataLabels:      application.Spec.Labels,
+			MetadataAnnotations: application.Spec.Annotations,
 		},
 		IngressController: &framework.Spec.IngressController,
 	}

--- a/internal/chart/application_chart.go
+++ b/internal/chart/application_chart.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/pkg/errors"
+
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 	"github.com/shipa-corp/ketch/internal/templates"
 )
@@ -61,6 +62,7 @@ type gatewayService struct {
 }
 
 type app struct {
+	ID          string        `json:"id"`
 	Name        string        `json:"name"`
 	Deployments []deployment  `json:"deployments"`
 	Env         []ketchv1.Env `json:"env"`
@@ -138,6 +140,7 @@ func New(application *ketchv1.App, framework *ketchv1.Framework, opts ...Option)
 
 	values := &values{
 		App: &app{
+			ID:      application.Spec.ID,
 			Name:    application.Name,
 			Ingress: *ingress,
 			Env:     application.Spec.Env,

--- a/internal/chart/application_chart_test.go
+++ b/internal/chart/application_chart_test.go
@@ -159,15 +159,24 @@ func TestNewApplicationChart(t *testing.T) {
 					Kind:       "Deployment",
 				},
 			}},
-			Annotations: []ketchv1.MetadataItem{{
-				Apply:             map[string]string{"theketch.io/test-annotation": "test-annotation-value"},
-				DeploymentVersion: 4,
-				ProcessName:       "web",
-				Target: ketchv1.Target{
-					APIVersion: "v1",
-					Kind:       "Service",
+			Annotations: []ketchv1.MetadataItem{
+				{
+					Apply:             map[string]string{"theketch.io/test-annotation": "test-annotation-value"},
+					DeploymentVersion: 4,
+					ProcessName:       "web",
+					Target: ketchv1.Target{
+						APIVersion: "v1",
+						Kind:       "Service",
+					},
 				},
-			}},
+				{
+					Apply:             map[string]string{"theketch.io/gateway-annotation": "test-gateway"},
+					Target: ketchv1.Target{
+						APIVersion: "networking.istio.io/v1alpha3",
+						Kind:       "Gateway",
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/chart/process.go
+++ b/internal/chart/process.go
@@ -153,8 +153,6 @@ func withLabels(labels []ketchv1.MetadataItem, deploymentVersion ketchv1.Deploym
 						p.PodExtra.ServiceMetadata.Labels = make(map[string]string)
 					}
 					p.PodExtra.ServiceMetadata.Labels[k] = v
-				} else {
-					return fmt.Errorf("unsupported target kind: %s", label.Target.Kind)
 				}
 			}
 		}
@@ -183,8 +181,6 @@ func withAnnotations(annotations []ketchv1.MetadataItem, deploymentVersion ketch
 						p.PodExtra.ServiceMetadata.Annotations = make(map[string]string)
 					}
 					p.PodExtra.ServiceMetadata.Annotations[k] = v
-				} else {
-					return fmt.Errorf("unsupported target kind: %s", annotation.Target.Kind)
 				}
 			}
 		}

--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -397,6 +397,10 @@ metadata:
   labels:
     theketch.io/app-name: "dashboard"
   name: dashboard-http-gateway
+  annotations:
+    theketch.io/metadata-item-kind: Gateway
+    theketch.io/metadata-item-apiVersion: networking.istio.io/v1alpha3
+    theketch.io/gateway-annotation: "test-gateway"
 spec:
   selector:
     istio: ingressgateway

--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "4"
@@ -363,6 +363,32 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
+---
+# Source: dashboard/templates/destinationRule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-dashboard-rule-3
+spec:
+  host: dashboard-web-3
+  subsets:
+    - name: v3
+      labels:
+        app: "dashboard"
+        version: "3"
+---
+# Source: dashboard/templates/destinationRule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-dashboard-rule-4
+spec:
+  host: dashboard-web-4
+  subsets:
+    - name: v4
+      labels:
+        app: "dashboard"
+        version: "4"
 ---
 # Source: dashboard/templates/gateway.yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -446,9 +472,11 @@ spec:
             host: dashboard-web-3
             port:
               number: 9090
+            subset: "v3"
           weight: 30
         - destination:
             host: dashboard-web-4
             port:
               number: 9091
+            subset: "v4"
           weight: 70

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "4"
@@ -335,6 +335,32 @@ spec:
           - containerPort: 9091
       imagePullSecrets:
             - name: default-image-pull-secret
+---
+# Source: dashboard/templates/destinationRule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-dashboard-rule-3
+spec:
+  host: dashboard-web-3
+  subsets:
+    - name: v3
+      labels:
+        app: "dashboard"
+        version: "3"
+---
+# Source: dashboard/templates/destinationRule.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-dashboard-rule-4
+spec:
+  host: dashboard-web-4
+  subsets:
+    - name: v4
+      labels:
+        app: "dashboard"
+        version: "4"
 ---
 # Source: dashboard/templates/gateway.yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -386,9 +412,11 @@ spec:
             host: dashboard-web-3
             port:
               number: 9090
+            subset: "v3"
           weight: 30
         - destination:
             host: dashboard-web-4
             port:
               number: 9091
+            subset: "v4"
           weight: 70

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -369,6 +369,10 @@ metadata:
   labels:
     theketch.io/app-name: "dashboard"
   name: dashboard-http-gateway
+  annotations:
+    theketch.io/metadata-item-kind: Gateway
+    theketch.io/metadata-item-apiVersion: networking.istio.io/v1alpha3
+    theketch.io/gateway-annotation: "test-gateway"
 spec:
   selector:
     istio: ingressgateway

--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "4"

--- a/internal/chart/testdata/charts/dashboard-nginx.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "4"

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "web"
     shipa.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "worker"
     shipa.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "web"
     shipa.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "worker"
     shipa.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "web"
     shipa.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       shipa.io/app-name: "dashboard"
       shipa.io/app-process: "web"
       shipa.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         shipa.io/app-name: "dashboard"
         shipa.io/app-process: "web"
         shipa.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "worker"
     shipa.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       shipa.io/app-name: "dashboard"
       shipa.io/app-process: "worker"
       shipa.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         shipa.io/app-name: "dashboard"
         shipa.io/app-process: "worker"
         shipa.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "web"
     shipa.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       shipa.io/app-name: "dashboard"
       shipa.io/app-process: "web"
       shipa.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         shipa.io/app-name: "dashboard"
         shipa.io/app-process: "web"
         shipa.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     shipa.io/app-name: "dashboard"
     shipa.io/app-process: "worker"
     shipa.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       shipa.io/app-name: "dashboard"
       shipa.io/app-process: "worker"
       shipa.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         shipa.io/app-name: "dashboard"
         shipa.io/app-process: "worker"
         shipa.io/app-deployment-version: "4"

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "4"

--- a/internal/chart/testdata/charts/dashboard-traefik.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "3"
@@ -49,7 +48,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "3"
@@ -73,7 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-deployment-version: "4"
@@ -99,7 +96,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-deployment-version: "4"
@@ -123,7 +119,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -136,7 +131,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "3"
@@ -144,7 +140,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "3"
@@ -193,7 +190,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-3
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -205,7 +201,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-3
+      app: "dashboard"
+      version: "3"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "3"
@@ -213,7 +210,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-3
+        app: "dashboard"
+        version: "3"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "3"
@@ -243,7 +241,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-web-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "web"
     theketch.io/app-process-replicas: "3"
@@ -255,7 +252,8 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: dashboard-web-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "web"
       theketch.io/app-deployment-version: "4"
@@ -263,7 +261,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-web-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "web"
         theketch.io/app-deployment-version: "4"
@@ -292,7 +291,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: dashboard-worker-4
     theketch.io/app-name: "dashboard"
     theketch.io/app-process: "worker"
     theketch.io/app-process-replicas: "1"
@@ -304,7 +302,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: dashboard-worker-4
+      app: "dashboard"
+      version: "4"
       theketch.io/app-name: "dashboard"
       theketch.io/app-process: "worker"
       theketch.io/app-deployment-version: "4"
@@ -312,7 +311,8 @@ spec:
   template:
     metadata:
       labels:
-        app: dashboard-worker-4
+        app: "dashboard"
+        version: "4"
         theketch.io/app-name: "dashboard"
         theketch.io/app-process: "worker"
         theketch.io/app-deployment-version: "4"

--- a/internal/templates/common/yamls/_helpers.tpl
+++ b/internal/templates/common/yamls/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+
+ketch.renderMetadata renders a labels/annotations section based on a given dict,
+the dict must have the following entries:
+{
+    "metadataItems": []MetadataItem{},    // a list of requests to add metadata
+    "kind": "<kind>",                   // all metadataItems with target.kind equals <kind> will be added
+    "apiVersion": "<apiVersion>",       // all metadataItems with target.apiVersion equals <kind> will be added
+}
+
+This is an example of usage:
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+    {{- $data := dict "kind" "Gateway" "apiVersion" "networking.istio.io/v1alpha3" "metadataItems" $.Values.app.metadataAnnotations }}
+    annotations: {{- include "ketch.renderMetadata" $data | nindent 4 }}
+
+Two theketch.io annotations are added to simplify debug and to avoid dealing with an empty "labels/annotations" section in yamls.
+
+*/}}
+{{- define "ketch.renderMetadata" -}}
+theketch.io/metadata-item-kind: {{ $.kind }}
+theketch.io/metadata-item-apiVersion: {{ $.apiVersion }}
+{{- range $_, $item := $.metadataItems }}
+  {{- if eq $item.target.kind $.kind }}
+    {{- if eq $item.target.apiVersion $.apiVersion }}
+        {{- range $key, $value := $item.apply }}
+{{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/internal/templates/common/yamls/deployment.yaml
+++ b/internal/templates/common/yamls/deployment.yaml
@@ -4,7 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
     {{ $.Values.app.group }}/app-process: {{ $process.name | quote }}
     {{ $.Values.app.group }}/app-process-replicas: {{ $process.units | quote }}
@@ -24,7 +23,8 @@ spec:
   replicas: {{ $process.units }}
   selector:
     matchLabels:
-      app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
+      app: {{ default $.Values.app.name $.Values.app.id | quote }}
+      version: {{ $deployment.version | quote }}
       {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
       {{ $.Values.app.group }}/app-process: {{ $process.name | quote }}
       {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}
@@ -32,7 +32,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
+        app: {{ default $.Values.app.name $.Values.app.id | quote }}
+        version: {{ $deployment.version | quote }}
         {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
         {{ $.Values.app.group }}/app-process: {{ $process.name | quote }}
         {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}

--- a/internal/templates/common/yamls/service.yaml
+++ b/internal/templates/common/yamls/service.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
     {{ $.Values.app.group }}/app-process: {{ $process.name | quote }}
     {{ $.Values.app.group }}/app-deployment-version: {{ $deployment.version | quote }}

--- a/internal/templates/istio/yamls/destinationRule.yaml
+++ b/internal/templates/istio/yamls/destinationRule.yaml
@@ -1,0 +1,18 @@
+{{- range $_ , $deployment := .Values.app.deployments }}
+  {{- range $_, $process := $deployment.processes }}
+  {{- if $process.routable }}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: shipa-{{ $.Values.app.name}}-rule-{{ $deployment.version }}
+spec:
+  host: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
+  subsets:
+    - name: v{{ $deployment.version }}
+      labels:
+        app: {{ default $.Values.app.name $.Values.app.id | quote }}
+        version: "{{ $deployment.version }}"
+---
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/internal/templates/istio/yamls/gateway.yaml
+++ b/internal/templates/istio/yamls/gateway.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
   name: {{ $.Values.app.name }}-http-gateway
+  {{- $data := dict "kind" "Gateway" "apiVersion" "networking.istio.io/v1alpha3" "metadataItems" $.Values.app.metadataAnnotations }}
+  annotations: {{- include "ketch.renderMetadata" $data | nindent 4 }}
 spec:
   selector:
     istio: ingressgateway

--- a/internal/templates/istio/yamls/virtualService.yaml
+++ b/internal/templates/istio/yamls/virtualService.yaml
@@ -33,6 +33,7 @@ spec:
             host: {{ printf "%s-%s-%v" $.Values.app.name $process.name $deployment.version }}
             port:
               number: {{ $process.publicServicePort }}
+            subset: "v{{ $deployment.version }}"
           weight: {{$deployment.routingSettings.weight}}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
This PR adds a DestinationRule in a way that istio time series will have `destination_app=<app.spec.id or app.name>` label

- [x] New feature (non-breaking change which adds functionality)
