### PR TITLE
[SHIPA-1944] Provide way to use user's SSL certificate for cnames

### DIFF
--- a/config/crd/bases/theketch.io_apps.yaml
+++ b/config/crd/bases/theketch.io_apps.yaml
@@ -2270,6 +2270,11 @@ spec:
                       properties:
                         name:
                           type: string
+                        secretName:
+                          description: SecretName if provided must contain an SSL
+                            certificate that will be used to serve this cname. Currently,
+                            the secret must be in the framework's namespace.
+                          type: string
                         secure:
                           type: boolean
                       required:

--- a/internal/api/v1beta1/app_types.go
+++ b/internal/api/v1beta1/app_types.go
@@ -71,6 +71,9 @@ type CnameList []Cname
 type Cname struct {
 	Name   string `json:"name"`
 	Secure bool   `json:"secure"`
+	// SecretName if provided must contain an SSL certificate that will be used to serve this cname.
+	// Currently, the secret must be in the framework's namespace.
+	SecretName string `json:"secretName,omitempty"`
 }
 
 // RoutingSettings contains a weight of the current deployment used to route incoming traffic.

--- a/internal/chart/application_chart_test.go
+++ b/internal/chart/application_chart_test.go
@@ -134,13 +134,9 @@ func TestNewApplicationChart(t *testing.T) {
 			Ingress: ketchv1.IngressSpec{
 				GenerateDefaultCname: true,
 				Cnames: []ketchv1.Cname{
-					{
-						Name:   "theketch.io",
-						Secure: true,
-					}, {
-						Name:   "app.theketch.io",
-						Secure: true,
-					},
+					{Name: "theketch.io", Secure: true},
+					{Name: "app.theketch.io", Secure: true},
+					{Name: "darkweb.theketch.io", Secure: true, SecretName: "darkweb-ssl"},
 				},
 			},
 			Labels: []ketchv1.MetadataItem{{
@@ -298,7 +294,7 @@ func TestNewApplicationChart(t *testing.T) {
 			require.Nil(t, err)
 
 			expectedFilename := filepath.Join(chartDirectory, fmt.Sprintf("%s.yaml", tt.wantYamlsFilename))
-			actualFilename := filepath.Join(chartDirectory, fmt.Sprintf("%s-output.yaml", tt.wantYamlsFilename))
+			actualFilename := filepath.Join(chartDirectory, fmt.Sprintf("%s.output.yaml", tt.wantYamlsFilename))
 
 			chartConfig := ChartConfig{
 				Version: "0.0.1",

--- a/internal/chart/ingress_test.go
+++ b/internal/chart/ingress_test.go
@@ -21,18 +21,17 @@ func TestNewIngress(t *testing.T) {
 		{
 			name: "happy",
 			cnames: ketchv1.CnameList{
-				{
-					Name:   "a.name",
-					Secure: true,
-				},
-				{
-					Name: "b.name",
-				},
+				{Name: "a.name"},
+				{Name: "b.name", Secure: true},
+				{Name: "c.name", Secure: true, SecretName: "c-ssl"},
 			},
 			clusterIssuer: "test-cluster-issuer",
 			expected: &ingress{
-				Https: []httpsEndpoint{{Cname: "a.name", SecretName: "my-app-cname-a-name", UniqueName: "my-app-https-a-name"}},
-				Http:  []string{"b.name"},
+				Http: []string{"a.name"},
+				Https: []httpsEndpoint{
+					{Cname: "b.name", SecretName: "my-app-cname-b-name", UniqueName: "my-app-https-b-name", ManagedBy: certManager},
+					{Cname: "c.name", SecretName: "c-ssl", UniqueName: "my-app-https-c-name", ManagedBy: user},
+				},
 			},
 		},
 		{

--- a/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio-cluster-issuer.yaml
@@ -430,6 +430,15 @@ spec:
     hosts:
     - app.theketch.io
   - port:
+      number: 443
+      name: https-3-darkweb.theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: darkweb-ssl
+    hosts:
+    - darkweb.theketch.io
+  - port:
       number: 80
       name: http-4
       protocol: HTTP
@@ -453,6 +462,15 @@ spec:
       credentialName: dashboard-cname-app-theketch-io
     hosts:
     - app.theketch.io
+  - port:
+      number: 443
+      name: https-4-darkweb.theketch.io
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: darkweb-ssl
+    hosts:
+    - darkweb.theketch.io
 ---
 # Source: dashboard/templates/virtualService.yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -468,6 +486,7 @@ spec:
     - dashboard.10.10.10.10.shipa.cloud
     - theketch.io
     - app.theketch.io
+    - darkweb.theketch.io
     gateways:
     - dashboard-http-gateway
     http:

--- a/internal/chart/testdata/charts/dashboard-istio.yaml
+++ b/internal/chart/testdata/charts/dashboard-istio.yaml
@@ -384,6 +384,7 @@ spec:
     hosts:
     - theketch.io
     - app.theketch.io
+    - darkweb.theketch.io
     - dashboard.20.20.20.20.shipa.cloud
   - port:
       number: 80
@@ -392,6 +393,7 @@ spec:
     hosts:
     - theketch.io
     - app.theketch.io
+    - darkweb.theketch.io
     - dashboard.20.20.20.20.shipa.cloud
 ---
 # Source: dashboard/templates/virtualService.yaml
@@ -407,6 +409,7 @@ spec:
     hosts:
     - theketch.io
     - app.theketch.io
+    - darkweb.theketch.io
     - dashboard.20.20.20.20.shipa.cloud
     gateways:
     - dashboard-http-gateway

--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -406,6 +406,12 @@ spec:
       - backend:
           serviceName: dashboard-web-3
           servicePort: 9090
+  - host: darkweb.theketch.io
+    http:
+      paths:
+      - backend:
+          serviceName: dashboard-web-3
+          servicePort: 9090
 ---
 # Source: dashboard/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -428,6 +434,12 @@ spec:
           serviceName: dashboard-web-4
           servicePort: 9091
   - host: app.theketch.io
+    http:
+      paths:
+      - backend:
+          serviceName: dashboard-web-4
+          servicePort: 9091
+  - host: darkweb.theketch.io
     http:
       paths:
       - backend:

--- a/internal/chart/testdata/charts/dashboard-nginx.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx.yaml
@@ -365,6 +365,15 @@ spec:
             port:
               number: 9090
         pathType: ImplementationSpecific
+  - host: darkweb.theketch.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: dashboard-web-3
+            port:
+              number: 9090
+        pathType: ImplementationSpecific
   - host: dashboard.20.20.20.20.shipa.cloud
     http:
       paths:
@@ -398,6 +407,15 @@ spec:
               number: 9091
         pathType: ImplementationSpecific
   - host: app.theketch.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: dashboard-web-4
+            port:
+              number: 9091
+        pathType: ImplementationSpecific
+  - host: darkweb.theketch.io
     http:
       paths:
       - backend:

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer-shipa.yaml
@@ -437,3 +437,29 @@ spec:
       weight: 70
   tls:
     secretName: dashboard-cname-app-theketch-io
+---
+# Source: dashboard/templates/https-ingress-routes.yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dashboard-https-darkweb-theketch-io
+  annotations:
+    kubernetes.io/ingress.class: "ingress-class"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+  labels:
+    shipa.io/app-name: "dashboard"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: Host("darkweb.theketch.io")
+    kind: Rule
+    services:
+    - name: dashboard-web-3
+      port: 9090
+      weight: 30
+    - name: dashboard-web-4
+      port: 9091
+      weight: 70
+  tls:
+    secretName: darkweb-ssl

--- a/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik-cluster-issuer.yaml
@@ -437,3 +437,29 @@ spec:
       weight: 70
   tls:
     secretName: dashboard-cname-app-theketch-io
+---
+# Source: dashboard/templates/https-ingress-routes.yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dashboard-https-darkweb-theketch-io
+  annotations:
+    kubernetes.io/ingress.class: "ingress-class"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+  labels:
+    theketch.io/app-name: "dashboard"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: Host("darkweb.theketch.io")
+    kind: Rule
+    services:
+    - name: dashboard-web-3
+      port: 9090
+      weight: 30
+    - name: dashboard-web-4
+      port: 9091
+      weight: 70
+  tls:
+    secretName: darkweb-ssl

--- a/internal/chart/testdata/charts/dashboard-traefik.yaml
+++ b/internal/chart/testdata/charts/dashboard-traefik.yaml
@@ -367,6 +367,15 @@ spec:
     - name: dashboard-web-4
       port: 9091
       weight: 70
+  - match: Host("darkweb.theketch.io")
+    kind: Rule
+    services:
+    - name: dashboard-web-3
+      port: 9090
+      weight: 30
+    - name: dashboard-web-4
+      port: 9091
+      weight: 70
   - match: Host("dashboard.20.20.20.20.shipa.cloud")
     kind: Rule
     services:

--- a/internal/templates/istio/yamls/certificate.yaml
+++ b/internal/templates/istio/yamls/certificate.yaml
@@ -1,4 +1,5 @@
-{{ range $_, $https := .Values.app.ingress.https }}
+{{- range $_, $https := .Values.app.ingress.https }}
+{{- if eq $https.managedBy "cert-manager" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -12,4 +13,5 @@ spec:
     name: {{ $.Values.ingressController.clusterIssuer }}
     kind: ClusterIssuer
 ---
+{{ end }}
 {{ end }}

--- a/internal/templates/nginx/yamls/certificate.yaml
+++ b/internal/templates/nginx/yamls/certificate.yaml
@@ -1,4 +1,5 @@
-{{ range $_, $https := .Values.app.ingress.https }}
+{{- range $_, $https := .Values.app.ingress.https }}
+{{- if eq $https.managedBy "cert-manager" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -11,4 +12,5 @@ spec:
     name: {{ $.Values.ingressController.clusterIssuer }}
     kind: ClusterIssuer
 ---
+{{ end }}
 {{ end }}

--- a/internal/templates/traefik/yamls/certificate.yaml
+++ b/internal/templates/traefik/yamls/certificate.yaml
@@ -1,4 +1,5 @@
-{{ range $_, $https := .Values.app.ingress.https }}
+{{- range $_, $https := .Values.app.ingress.https }}
+{{- if eq $https.managedBy "cert-manager" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -11,4 +12,5 @@ spec:
     name: {{ $.Values.ingressController.clusterIssuer }}
     kind: ClusterIssuer
 ---
+{{ end }}
 {{ end }}


### PR DESCRIPTION
This PR adds a new `secretName` field to Ketch App CRD. If provided, ketch doesn't obtain an SSL certificate for such a cname but expects that a given secret contains a valid SSL certificate. 

```yaml
spec:
  ingress:
    cnames:
    - name: app.shipa.io
      secure: true
    - name: dashboard.shipa.io
      secretName: my-secret
      secure: true
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)

