### PR TITLE
Add istio integration test

### DIFF
--- a/cli_tests/install_ketch.sh
+++ b/cli_tests/install_ketch.sh
@@ -37,6 +37,9 @@ helm repo add traefik https://helm.traefik.io/traefik
 helm repo update
 helm install traefik traefik/traefik
 
+# istio
+ISTIO_VERSION=1.11.0 && curl -L -k https://istio.io/downloadIstio |ISTIO_VERSION=1.11.0 sh - && cd istio-$ISTIO_VERSION && ./bin/istioctl install --set profile=demo -y
+
 # nginx
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update


### PR DESCRIPTION
# Description

Adds testing assuring that apps & frameworks can be created & deleted with istio ingress-controller. Ticket SHIPA-2024 indicates that an istio-based framework fail to remove. This doesn't address the issue directly but adds integration tests to assure the issue isn't happening.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [ ] All added public packages, funcs, and types have been documented with doc comments
- [ ] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
