### PR TITLE
[SHIPA-2024] Prunes dead apps from framework status when removing framework

### DIFF
--- a/cmd/ketch/framework_remove.go
+++ b/cmd/ketch/framework_remove.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ketchv1 "github.com/shipa-corp/ketch/internal/api/v1beta1"
 )
@@ -48,6 +49,9 @@ func frameworkRemove(ctx context.Context, cfg config, options frameworkRemoveOpt
 		return fmt.Errorf("failed to get framework: %w", err)
 	}
 
+	if err := pruneRemovedAppsFromStatus(ctx, cfg, framework); err != nil {
+		return fmt.Errorf("failed to update framework's apps: %w", err)
+	}
 	if userWantsToRemoveNamespace(framework.Spec.NamespaceName, out) {
 		if err := checkNamespaceAdditionalFrameworks(ctx, cfg, &framework); err != nil {
 			printNsRemovalErr(out, err)
@@ -126,4 +130,24 @@ func removeNamespace(ctx context.Context, cfg config, framework *ketchv1.Framewo
 	}
 
 	return nil
+}
+
+// pruneRemovedAppsFromStatus lists apps and removes any apps that are not present on the system from a framework's status.
+func pruneRemovedAppsFromStatus(ctx context.Context, cfg config, framework ketchv1.Framework) error {
+	var apps ketchv1.AppList
+	if err := cfg.Client().List(ctx, &apps); err != nil {
+		return fmt.Errorf("failed to list framework apps: %w", err)
+	}
+	var updatedApps []string
+	for _, frameworkApp := range framework.Status.Apps {
+		for _, app := range apps.Items {
+			if app.Name == frameworkApp {
+				updatedApps = append(updatedApps, frameworkApp)
+			}
+		}
+	}
+	patchedFramework := framework
+	patchedFramework.Status.Apps = updatedApps
+	patch := client.MergeFrom(&framework)
+	return cfg.Client().Status().Patch(ctx, &patchedFramework, patch)
 }


### PR DESCRIPTION
# Description

Deleting a framework and it's apps simultaneously, e.g. terraform, script, etc. can occasionally create a situation where an app is removed, but is still in the framework's `framework.Status.Apps` list. This can cause frustration since a user cannot remove the framework ("contains running apps" error) nor can they remove the already-removed app. This PR prunes non-existent apps from the `framework.Status.Apps` list prior to the framework delete.

Fixes # [2024](https://shipaio.atlassian.net/browse/SHIPA-2024?atlOrigin=eyJpIjoiYTY1YjE3YjMyMzhiNGFjMmE0ZGU2MjA0NTJkODY5MTgiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (documentation addition or typo, file relocation)

## Testing

- [x] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

## Documentation

- [x] All added public packages, funcs, and types have been documented with doc comments
- [x] I have commented my code, particularly in hard-to-understand areas

## Final Checklist:

- [x] I followed standard [GitHub flow](https://guides.github.com/introduction/flow/) guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
