### PR TITLE
Rollback to the previous usage of nginx.ingress.kubernetes.io/canary

### DIFF
--- a/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx-cluster-issuer.yaml
@@ -340,11 +340,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dashboard-http-ingress-3
+  name: dashboard-0-https-ingress
   annotations:
     kubernetes.io/ingress.class: "ingress-class"
-    nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "30"
     theketch.io/metadata-item-kind: Ingress
     theketch.io/metadata-item-apiVersion: networking.k8s.io/v1
     theketch.io/ingress-annotation: "test-ingress"
@@ -366,7 +364,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dashboard-http-ingress-4
+  name: dashboard-1-https-ingress
   annotations:
     kubernetes.io/ingress.class: "ingress-class"
     nginx.ingress.kubernetes.io/canary: "true"
@@ -392,11 +390,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dashboard-https-ingress-3
+  name: dashboard-0-https-ingress
   annotations:
     kubernetes.io/ingress.class: "ingress-class"
-    nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "30"
   labels:
     theketch.io/app-name: "dashboard"
 spec:
@@ -446,7 +442,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dashboard-https-ingress-4
+  name: dashboard-1-https-ingress
   annotations:
     kubernetes.io/ingress.class: "ingress-class"
     nginx.ingress.kubernetes.io/canary: "true"

--- a/internal/chart/testdata/charts/dashboard-nginx.yaml
+++ b/internal/chart/testdata/charts/dashboard-nginx.yaml
@@ -340,11 +340,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dashboard-http-ingress-3
+  name: dashboard-0-https-ingress
   annotations:
     kubernetes.io/ingress.class: "gke"
-    nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "30"
     theketch.io/metadata-item-kind: Ingress
     theketch.io/metadata-item-apiVersion: networking.k8s.io/v1
     theketch.io/ingress-annotation: "test-ingress"
@@ -393,7 +391,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dashboard-http-ingress-4
+  name: dashboard-1-https-ingress
   annotations:
     kubernetes.io/ingress.class: "gke"
     nginx.ingress.kubernetes.io/canary: "true"

--- a/internal/templates/nginx/yamls/ingress.yaml
+++ b/internal/templates/nginx/yamls/ingress.yaml
@@ -5,13 +5,15 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $.Values.app.name }}-http-ingress-{{ $deployment.version }}
+  name: {{ $.Values.app.name }}-{{ $i }}-https-ingress
   annotations:
     {{- if $.Values.ingressController.className }}
     kubernetes.io/ingress.class: {{ $.Values.ingressController.className | quote }}
     {{- end }}
+    {{- if gt $i 0 }}
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "{{ $deployment.routingSettings.weight }}"
+    {{- end }}
     {{- $data := dict "kind" "Ingress" "apiVersion" "networking.k8s.io/v1" "metadataItems" $.Values.app.metadataAnnotations }}
     {{- include "ketch.renderMetadata" $data | nindent 4 }}
   labels:
@@ -46,13 +48,15 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $.Values.app.name }}-https-ingress-{{ $deployment.version }}
+  name: {{ $.Values.app.name }}-{{ $i }}-https-ingress
   annotations:
     {{- if $.Values.ingressController.className }}
     kubernetes.io/ingress.class: {{ $.Values.ingressController.className | quote }}
     {{- end }}
+    {{- if gt $i 0 }}
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "{{ $deployment.routingSettings.weight }}"
+    {{- end }}
   labels:
     {{ $.Values.app.group }}/app-name: {{ $.Values.app.name | quote }}
 spec:


### PR DESCRIPTION
   According to the documentation https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#canary
the annotation can be applied once per Ingress rule.

   This commit rollbacks to the previous scheme that is defined as follows:
    `<app-name>-0-http-ingress` - an Ingress name of the first deployment in app.spec.deployments, it always goes without the annotation,
   `<app-name>-1-http-ingress` - an Ingress name of the second deployment in app.spec.deployments, it always goes with the annotation.
    Thus
     * if an application has one active deployment, it is not annotated (correct, that's what we need).
     * if an application has two deployments, only the second one has the annotation (correct, that's what we need).

   There are a couple issues with the current approach (that is being reverted by this commit):
   1. if an application has one Ingress object, it is always annotated and nginx doesn't handle the ingress (doesn't work).
   2. the naming scheme `<app-name>-http-ingress-<deployment-version>` doesn't work even if we remove the annotation.
   For example, ingresses "dashboard-http-ingress-4" and "dashboard-http-ingress-5" have the
same ingress rules inside and nginx admission controller reject saving them, as a result ketch can't update the app's helm chart.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] New tests were added with this PR that prove my fix is effective or that my feature works (describe below this bullet)
- [ ] This change requires no testing (i.e. documentation update)

#
